### PR TITLE
Avoid throwing .NET Exceptions back to Dokan driver

### DIFF
--- a/DokanNet.Tests/DirectoryInfoTest.cs
+++ b/DokanNet.Tests/DirectoryInfoTest.cs
@@ -742,9 +742,9 @@ namespace DokanNet.Tests
             // WARNING: This is probably an error in the Dokan driver!
             fixture.SetupOpenDirectoryWithoutCleanup(string.Empty);
             fixture.SetupMoveFile(path, destinationPath, false);
-            fixture.SetupCleanupFile(destinationPath, isDirectory: true);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationPath/* This call is probably redundant. */);
+            fixture.SetupCloseFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCleanupFile(destinationPath);
 #endif
 
             var sut = new DirectoryInfo(DokanOperationsFixture.DirectoryName.AsDriveBasedPath());
@@ -772,9 +772,9 @@ namespace DokanNet.Tests
             fixture.SetupGetFileInformation(path, FileAttributes.Directory);
             fixture.SetupOpenDirectoryWithoutCleanup(DokanOperationsFixture.DestinationDirectoryName.AsRootedPath());
             fixture.SetupMoveFile(path, destinationPath, false);
-            fixture.SetupCleanupFile(destinationPath, isDirectory: true);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationPath/* This call is probably redundant. */);
+            fixture.SetupCloseFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCleanupFile(destinationPath);
 #endif
 
             var sut = new DirectoryInfo(origin.AsDriveBasedPath());

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -17,38 +17,172 @@ namespace DokanNet.Tests
         {
             public IDokanOperations Target { get; set; }
 
+            private delegate TResult FuncOut2<in T1, T2, in T3, out TResult>(T1 arg1, out T2 arg2, T3 arg3);
+
+            private delegate TResult FuncOut2<in T1, T2, in T3, in T4, out TResult>(T1 arg1, out T2 arg2, T3 arg3, T4 arg4);
+
+            private delegate TResult FuncOut123<T1, T2, T3, in T4, out TResult>(out T1 arg1, out T2 arg2, out T3 arg3, T4 arg4);
+
+            private delegate TResult FuncOut3<in T1, in T2, T3, in T4, in T5, out TResult>(T1 arg1, T2 arg2, out T3 arg3, T4 arg4, T5 arg5);
+
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute(Func<DokanResult> func)
+            private static DokanResult TryExecute(DokanFileInfo info, Func<DokanFileInfo, DokanResult> func)
             {
                 try
                 {
-                    return func();
+                    return func(info);
                 }
                 catch (Exception ex)
                 {
-                    Trace($"**{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{nameof(func)} ({info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute(string fileName, DokanFileInfo info, Func<string, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(fileName, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({fileName}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute<T>(string fileName, T arg, DokanFileInfo info, Func<string, T, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(fileName, arg, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({fileName}, {arg}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute<T1, T2>(string fileName, T1 arg1, T2 arg2, DokanFileInfo info, Func<string, T1, T2, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(fileName, arg1, arg2, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({fileName}, {arg1}, {arg2}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute<T1, T2, T3>(string fileName, T1 arg1, T2 arg2, T3 arg3, DokanFileInfo info, Func<string, T1, T2, T3, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(fileName, arg1, arg2, arg3, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({fileName}, {arg1}, {arg2}, {arg3}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute<TOut>(string fileName, out TOut outParameter, DokanFileInfo info, FuncOut2<string, TOut, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(fileName, out outParameter, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({fileName}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    outParameter = default(TOut);
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute<TOut, TIn>(string fileName, out TOut argOut, TIn argIn, DokanFileInfo info, FuncOut2<string, TOut, TIn, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(fileName, out argOut, argIn, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({fileName}, {argIn}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    argOut = default(TOut);
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute<TIn1, TOut, TIn2>(string fileName, TIn1 argIn1, out TOut argOut, TIn2 argIn2, DokanFileInfo info, FuncOut3<string, TIn1, TOut, TIn2, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(fileName, argIn1, out argOut, argIn2, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({fileName}, {argIn1}, {argIn2}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    argOut = default(TOut);
+                    return DokanResult.ExceptionInService;
+                }
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+                Justification = "Explicit Exception handler")]
+            private static DokanResult TryExecute<TOut1, TOut2, TOut3>(out TOut1 outParameter1, out TOut2 outParameter2, out TOut3 outParameter3, DokanFileInfo info, FuncOut123<TOut1, TOut2, TOut3, DokanFileInfo, DokanResult> func)
+            {
+                try
+                {
+                    return func(out outParameter1, out outParameter2, out outParameter3, info);
+                }
+                catch (Exception ex)
+                {
+                    Trace($"{nameof(func)} ({info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    outParameter1 = default(TOut1);
+                    outParameter2 = default(TOut2);
+                    outParameter3 = default(TOut3);
                     return DokanResult.ExceptionInService;
                 }
             }
 
             public DokanResult Cleanup(string fileName, DokanFileInfo info)
-                => TryExecute(() => Target.Cleanup(fileName, info));
+                => TryExecute(fileName, info, (f, i) => Target.Cleanup(f, i));
 
             public DokanResult CloseFile(string fileName, DokanFileInfo info)
-                => TryExecute(() => Target.CloseFile(fileName, info));
+                => TryExecute(fileName, info, (f, i) => Target.CloseFile(f, i));
 
             public DokanResult CreateDirectory(string fileName, DokanFileInfo info)
-                => TryExecute(() => Target.CreateDirectory(fileName, info));
+                => TryExecute(fileName, info, (f, i) => Target.CreateDirectory(f, i));
 
             public DokanResult CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, DokanFileInfo info)
-                => TryExecute(() => Target.CreateFile(fileName, access, share, mode, options, attributes, info));
+                => TryExecute(fileName, info, (f, i) => Target.CreateFile(f, access, share, mode, options, attributes, i));
 
             public DokanResult DeleteDirectory(string fileName, DokanFileInfo info)
-                => TryExecute(() => Target.DeleteDirectory(fileName, info));
+                => TryExecute(fileName, info, (f, i) => Target.DeleteDirectory(f, i));
 
             public DokanResult DeleteFile(string fileName, DokanFileInfo info)
-                => TryExecute(() => Target.DeleteFile(fileName, info));
+                => TryExecute(fileName, info, (f, i) => Target.DeleteFile(f, i));
 
             public DokanResult EnumerateNamedStreams(string fileName, IntPtr enumContext, out string streamName, out long streamSize, DokanFileInfo info)
             {
@@ -58,58 +192,58 @@ namespace DokanNet.Tests
             }
 
             public DokanResult FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info)
-                => Target.FindFiles(fileName, out files, info);
+                => TryExecute(fileName, out files, info, (string f, out IList<FileInformation> o, DokanFileInfo i) => Target.FindFiles(f, out o, i));
 
             public DokanResult FlushFileBuffers(string fileName, DokanFileInfo info)
-                => TryExecute(() => Target.FlushFileBuffers(fileName, info));
+                => TryExecute(fileName, info, (f, i) => Target.FlushFileBuffers(f, i));
 
             public DokanResult GetDiskFreeSpace(out long freeBytesAvailable, out long totalNumberOfBytes, out long totalNumberOfFreeBytes, DokanFileInfo info)
-                => Target.GetDiskFreeSpace(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, info);
+                => TryExecute(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, info, (out long a, out long t, out long f, DokanFileInfo i) => Target.GetDiskFreeSpace(out a, out t, out f, i));
 
             public DokanResult GetFileInformation(string fileName, out FileInformation fileInfo, DokanFileInfo info)
-                => Target.GetFileInformation(fileName, out fileInfo, info);
+                => TryExecute(fileName, out fileInfo, info, (string f, out FileInformation fi, DokanFileInfo i) => Target.GetFileInformation(f, out fi, i));
 
             public DokanResult GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
-                => Target.GetFileSecurity(fileName, out security, sections, info);
+                => TryExecute(fileName, out security, sections, info, (string f, out FileSystemSecurity s, AccessControlSections a, DokanFileInfo i) => Target.GetFileSecurity(f, out s, a, i));
 
             public DokanResult GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features, out string fileSystemName, DokanFileInfo info)
-                => Target.GetVolumeInformation(out volumeLabel, out features, out fileSystemName, info);
+                => TryExecute(out volumeLabel, out features, out fileSystemName, info, (out string v, out FileSystemFeatures f, out string n, DokanFileInfo i) => Target.GetVolumeInformation(out v, out f, out n, i));
 
             public DokanResult LockFile(string fileName, long offset, long length, DokanFileInfo info)
-                => TryExecute(() => Target.LockFile(fileName, offset, length, info));
+                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.LockFile(f, o, l, i));
 
             public DokanResult MoveFile(string oldName, string newName, bool replace, DokanFileInfo info)
-                => TryExecute(() => Target.MoveFile(oldName, newName, replace, info));
+                => TryExecute(oldName, newName, replace, info, (o, n, r, i) => Target.MoveFile(o, n, r, i));
 
             public DokanResult OpenDirectory(string fileName, DokanFileInfo info)
-                => TryExecute(() => Target.OpenDirectory(fileName, info));
+                => TryExecute(fileName, info, (f, i) => Target.OpenDirectory(f, i));
 
             public DokanResult ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, DokanFileInfo info)
-                => Target.ReadFile(fileName, buffer, out bytesRead, offset, info);
+                => TryExecute(fileName, buffer, out bytesRead, offset, info, (string f, byte[] b, out int r, long o, DokanFileInfo i) => Target.ReadFile(f, b, out r, o, i));
 
             public DokanResult SetAllocationSize(string fileName, long length, DokanFileInfo info)
-                => TryExecute(() => Target.SetAllocationSize(fileName, length, info));
+                => TryExecute(fileName, length, info, (f, l, i) => Target.SetAllocationSize(f, l, i));
 
             public DokanResult SetEndOfFile(string fileName, long length, DokanFileInfo info)
-                => TryExecute(() => Target.SetEndOfFile(fileName, length, info));
+                => TryExecute(fileName, length, info, (f, l, i) => Target.SetEndOfFile(f, l, i));
 
             public DokanResult SetFileAttributes(string fileName, FileAttributes attributes, DokanFileInfo info)
-                => TryExecute(() => Target.SetFileAttributes(fileName, attributes, info));
+                => TryExecute(fileName, attributes, info, (f, a, i) => Target.SetFileAttributes(f, a, i));
 
             public DokanResult SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
-                => TryExecute(() => Target.SetFileSecurity(fileName, security, sections, info));
+                => TryExecute(fileName, security, sections, info, (f, s, a, i) => Target.SetFileSecurity(f, s, a, i));
 
             public DokanResult SetFileTime(string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, DokanFileInfo info)
-                => TryExecute(() => Target.SetFileTime(fileName, creationTime, lastAccessTime, lastWriteTime, info));
+                => TryExecute(fileName, creationTime, lastAccessTime, lastWriteTime, info, (f, c, a, w, i) => Target.SetFileTime(f, c, a, w, i));
 
             public DokanResult UnlockFile(string fileName, long offset, long length, DokanFileInfo info)
-                => TryExecute(() => Target.UnlockFile(fileName, offset, length, info));
+                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.UnlockFile(f, o, l, i));
 
             public DokanResult Unmount(DokanFileInfo info)
-                => TryExecute(() => Target.Unmount(info));
+                => TryExecute(info, i => Target.Unmount(i));
 
             public DokanResult WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info)
-                => Target.WriteFile(fileName, buffer, out bytesWritten, offset, info);
+                => TryExecute(fileName, buffer, out bytesWritten, offset, info, (string f, byte[] b, out int w, long o, DokanFileInfo i) => Target.WriteFile(f, b, out w, o, i));
         }
 
         public const char MOUNT_POINT = 'Z';

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -17,6 +17,8 @@ namespace DokanNet.Tests
         {
             public IDokanOperations Target { get; set; }
 
+            public bool HasUnmatchedInvocations { get; set; }
+
             private delegate TResult FuncOut2<in T1, T2, in T3, out TResult>(T1 arg1, out T2 arg2, T3 arg3);
 
             private delegate TResult FuncOut2<in T1, T2, in T3, in T4, out TResult>(T1 arg1, out T2 arg2, T3 arg3, T4 arg4);
@@ -27,7 +29,7 @@ namespace DokanNet.Tests
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute(DokanFileInfo info, Func<DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute(DokanFileInfo info, Func<DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -35,14 +37,16 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} ({info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     return DokanResult.ExceptionInService;
                 }
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute(string fileName, DokanFileInfo info, Func<string, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute(string fileName, DokanFileInfo info, Func<string, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -50,14 +54,16 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({fileName}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} (\"{fileName}\", {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     return DokanResult.ExceptionInService;
                 }
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute<T>(string fileName, T arg, DokanFileInfo info, Func<string, T, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute<T>(string fileName, T arg, DokanFileInfo info, Func<string, T, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -65,14 +71,16 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({fileName}, {arg}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} (\"{fileName}\", {arg}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     return DokanResult.ExceptionInService;
                 }
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute<T1, T2>(string fileName, T1 arg1, T2 arg2, DokanFileInfo info, Func<string, T1, T2, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute<T1, T2>(string fileName, T1 arg1, T2 arg2, DokanFileInfo info, Func<string, T1, T2, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -80,14 +88,16 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({fileName}, {arg1}, {arg2}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} (\"{fileName}\", {arg1}, {arg2}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     return DokanResult.ExceptionInService;
                 }
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute<T1, T2, T3>(string fileName, T1 arg1, T2 arg2, T3 arg3, DokanFileInfo info, Func<string, T1, T2, T3, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute<T1, T2, T3>(string fileName, T1 arg1, T2 arg2, T3 arg3, DokanFileInfo info, Func<string, T1, T2, T3, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -95,14 +105,16 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({fileName}, {arg1}, {arg2}, {arg3}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} (\"{fileName}\", {arg1}, {arg2}, {arg3}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     return DokanResult.ExceptionInService;
                 }
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute<TOut>(string fileName, out TOut outParameter, DokanFileInfo info, FuncOut2<string, TOut, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute<TOut>(string fileName, out TOut outParameter, DokanFileInfo info, FuncOut2<string, TOut, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -110,7 +122,9 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({fileName}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} (\"{fileName}\", {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     outParameter = default(TOut);
                     return DokanResult.ExceptionInService;
                 }
@@ -118,7 +132,7 @@ namespace DokanNet.Tests
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute<TOut, TIn>(string fileName, out TOut argOut, TIn argIn, DokanFileInfo info, FuncOut2<string, TOut, TIn, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute<TOut, TIn>(string fileName, out TOut argOut, TIn argIn, DokanFileInfo info, FuncOut2<string, TOut, TIn, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -126,7 +140,9 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({fileName}, {argIn}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} (\"{fileName}\", {argIn}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     argOut = default(TOut);
                     return DokanResult.ExceptionInService;
                 }
@@ -134,7 +150,7 @@ namespace DokanNet.Tests
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute<TIn1, TOut, TIn2>(string fileName, TIn1 argIn1, out TOut argOut, TIn2 argIn2, DokanFileInfo info, FuncOut3<string, TIn1, TOut, TIn2, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute<TIn1, TOut, TIn2>(string fileName, TIn1 argIn1, out TOut argOut, TIn2 argIn2, DokanFileInfo info, FuncOut3<string, TIn1, TOut, TIn2, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -142,7 +158,9 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({fileName}, {argIn1}, {argIn2}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} (\"{fileName}\", {argIn1}, {argIn2}, {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     argOut = default(TOut);
                     return DokanResult.ExceptionInService;
                 }
@@ -150,7 +168,7 @@ namespace DokanNet.Tests
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private static DokanResult TryExecute<TOut1, TOut2, TOut3>(out TOut1 outParameter1, out TOut2 outParameter2, out TOut3 outParameter3, DokanFileInfo info, FuncOut123<TOut1, TOut2, TOut3, DokanFileInfo, DokanResult> func)
+            private DokanResult TryExecute<TOut1, TOut2, TOut3>(out TOut1 outParameter1, out TOut2 outParameter2, out TOut3 outParameter3, DokanFileInfo info, FuncOut123<TOut1, TOut2, TOut3, DokanFileInfo, DokanResult> func, string funcName)
             {
                 try
                 {
@@ -158,7 +176,9 @@ namespace DokanNet.Tests
                 }
                 catch (Exception ex)
                 {
-                    Trace($"{nameof(func)} ({info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    Trace($"{funcName} ({info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
+                    if (ex is MockException)
+                        HasUnmatchedInvocations = true;
                     outParameter1 = default(TOut1);
                     outParameter2 = default(TOut2);
                     outParameter3 = default(TOut3);
@@ -167,83 +187,84 @@ namespace DokanNet.Tests
             }
 
             public DokanResult Cleanup(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.Cleanup(f, i));
+                => TryExecute(fileName, info, (f, i) => Target.Cleanup(f, i), nameof(Cleanup));
 
             public DokanResult CloseFile(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.CloseFile(f, i));
+                => TryExecute(fileName, info, (f, i) => Target.CloseFile(f, i), nameof(CloseFile));
 
             public DokanResult CreateDirectory(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.CreateDirectory(f, i));
+                => TryExecute(fileName, info, (f, i) => Target.CreateDirectory(f, i), nameof(CreateDirectory));
 
             public DokanResult CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.CreateFile(f, access, share, mode, options, attributes, i));
+                => TryExecute(fileName, info, (f, i) => Target.CreateFile(f, access, share, mode, options, attributes, i), nameof(CreateFile));
 
             public DokanResult DeleteDirectory(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.DeleteDirectory(f, i));
+                => TryExecute(fileName, info, (f, i) => Target.DeleteDirectory(f, i), nameof(DeleteDirectory));
 
             public DokanResult DeleteFile(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.DeleteFile(f, i));
+                => TryExecute(fileName, info, (f, i) => Target.DeleteFile(f, i), nameof(DeleteFile));
 
             public DokanResult EnumerateNamedStreams(string fileName, IntPtr enumContext, out string streamName, out long streamSize, DokanFileInfo info)
             {
                 streamName = string.Empty;
                 streamSize = 0;
+                Trace($"{nameof(EnumerateNamedStreams)} (\"{fileName}\", {enumContext}) -> {DokanResult.NotImplemented}");
                 return DokanResult.NotImplemented;
             }
 
             public DokanResult FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info)
-                => TryExecute(fileName, out files, info, (string f, out IList<FileInformation> o, DokanFileInfo i) => Target.FindFiles(f, out o, i));
+                => TryExecute(fileName, out files, info, (string f, out IList<FileInformation> o, DokanFileInfo i) => Target.FindFiles(f, out o, i), nameof(FindFiles));
 
             public DokanResult FlushFileBuffers(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.FlushFileBuffers(f, i));
+                => TryExecute(fileName, info, (f, i) => Target.FlushFileBuffers(f, i), nameof(FlushFileBuffers));
 
             public DokanResult GetDiskFreeSpace(out long freeBytesAvailable, out long totalNumberOfBytes, out long totalNumberOfFreeBytes, DokanFileInfo info)
-                => TryExecute(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, info, (out long a, out long t, out long f, DokanFileInfo i) => Target.GetDiskFreeSpace(out a, out t, out f, i));
+                => TryExecute(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, info, (out long a, out long t, out long f, DokanFileInfo i) => Target.GetDiskFreeSpace(out a, out t, out f, i), nameof(GetDiskFreeSpace));
 
             public DokanResult GetFileInformation(string fileName, out FileInformation fileInfo, DokanFileInfo info)
-                => TryExecute(fileName, out fileInfo, info, (string f, out FileInformation fi, DokanFileInfo i) => Target.GetFileInformation(f, out fi, i));
+                => TryExecute(fileName, out fileInfo, info, (string f, out FileInformation fi, DokanFileInfo i) => Target.GetFileInformation(f, out fi, i), nameof(GetFileInformation));
 
             public DokanResult GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
-                => TryExecute(fileName, out security, sections, info, (string f, out FileSystemSecurity s, AccessControlSections a, DokanFileInfo i) => Target.GetFileSecurity(f, out s, a, i));
+                => TryExecute(fileName, out security, sections, info, (string f, out FileSystemSecurity s, AccessControlSections a, DokanFileInfo i) => Target.GetFileSecurity(f, out s, a, i), nameof(GetFileSecurity));
 
             public DokanResult GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features, out string fileSystemName, DokanFileInfo info)
-                => TryExecute(out volumeLabel, out features, out fileSystemName, info, (out string v, out FileSystemFeatures f, out string n, DokanFileInfo i) => Target.GetVolumeInformation(out v, out f, out n, i));
+                => TryExecute(out volumeLabel, out features, out fileSystemName, info, (out string v, out FileSystemFeatures f, out string n, DokanFileInfo i) => Target.GetVolumeInformation(out v, out f, out n, i), nameof(GetVolumeInformation));
 
             public DokanResult LockFile(string fileName, long offset, long length, DokanFileInfo info)
-                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.LockFile(f, o, l, i));
+                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.LockFile(f, o, l, i), nameof(LockFile));
 
             public DokanResult MoveFile(string oldName, string newName, bool replace, DokanFileInfo info)
-                => TryExecute(oldName, newName, replace, info, (o, n, r, i) => Target.MoveFile(o, n, r, i));
+                => TryExecute(oldName, newName, replace, info, (o, n, r, i) => Target.MoveFile(o, n, r, i), nameof(MoveFile));
 
             public DokanResult OpenDirectory(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.OpenDirectory(f, i));
+                => TryExecute(fileName, info, (f, i) => Target.OpenDirectory(f, i), nameof(OpenDirectory));
 
             public DokanResult ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, DokanFileInfo info)
-                => TryExecute(fileName, buffer, out bytesRead, offset, info, (string f, byte[] b, out int r, long o, DokanFileInfo i) => Target.ReadFile(f, b, out r, o, i));
+                => TryExecute(fileName, buffer, out bytesRead, offset, info, (string f, byte[] b, out int r, long o, DokanFileInfo i) => Target.ReadFile(f, b, out r, o, i), nameof(ReadFile));
 
             public DokanResult SetAllocationSize(string fileName, long length, DokanFileInfo info)
-                => TryExecute(fileName, length, info, (f, l, i) => Target.SetAllocationSize(f, l, i));
+                => TryExecute(fileName, length, info, (f, l, i) => Target.SetAllocationSize(f, l, i), nameof(SetAllocationSize));
 
             public DokanResult SetEndOfFile(string fileName, long length, DokanFileInfo info)
-                => TryExecute(fileName, length, info, (f, l, i) => Target.SetEndOfFile(f, l, i));
+                => TryExecute(fileName, length, info, (f, l, i) => Target.SetEndOfFile(f, l, i), nameof(SetEndOfFile));
 
             public DokanResult SetFileAttributes(string fileName, FileAttributes attributes, DokanFileInfo info)
-                => TryExecute(fileName, attributes, info, (f, a, i) => Target.SetFileAttributes(f, a, i));
+                => TryExecute(fileName, attributes, info, (f, a, i) => Target.SetFileAttributes(f, a, i), nameof(SetFileAttributes));
 
             public DokanResult SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
-                => TryExecute(fileName, security, sections, info, (f, s, a, i) => Target.SetFileSecurity(f, s, a, i));
+                => TryExecute(fileName, security, sections, info, (f, s, a, i) => Target.SetFileSecurity(f, s, a, i), nameof(SetFileSecurity));
 
             public DokanResult SetFileTime(string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, DokanFileInfo info)
-                => TryExecute(fileName, creationTime, lastAccessTime, lastWriteTime, info, (f, c, a, w, i) => Target.SetFileTime(f, c, a, w, i));
+                => TryExecute(fileName, creationTime, lastAccessTime, lastWriteTime, info, (f, c, a, w, i) => Target.SetFileTime(f, c, a, w, i), nameof(SetFileTime));
 
             public DokanResult UnlockFile(string fileName, long offset, long length, DokanFileInfo info)
-                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.UnlockFile(f, o, l, i));
+                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.UnlockFile(f, o, l, i), nameof(UnlockFile));
 
             public DokanResult Unmount(DokanFileInfo info)
-                => TryExecute(info, i => Target.Unmount(i));
+                => TryExecute(info, i => Target.Unmount(i), nameof(Unmount));
 
             public DokanResult WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info)
-                => TryExecute(fileName, buffer, out bytesWritten, offset, info, (string f, byte[] b, out int w, long o, DokanFileInfo i) => Target.WriteFile(f, b, out w, o, i));
+                => TryExecute(fileName, buffer, out bytesWritten, offset, info, (string f, byte[] b, out int w, long o, DokanFileInfo i) => Target.WriteFile(f, b, out w, o, i), nameof(WriteFile));
         }
 
         public const char MOUNT_POINT = 'Z';
@@ -351,10 +372,12 @@ namespace DokanNet.Tests
         {
             Instance = new DokanOperationsFixture();
             proxy.Target = Instance.operations.Object;
+            proxy.HasUnmatchedInvocations = false;
         }
 
-        internal static void ClearInstance()
+        internal static void ClearInstance(out bool hasUnmatchedInvocations)
         {
+            hasUnmatchedInvocations = proxy.HasUnmatchedInvocations;
             proxy.Target = null;
             Instance = null;
         }
@@ -682,7 +705,7 @@ namespace DokanNet.Tests
             operations
                 .Setup(d => d.OpenDirectory(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
                 .Returns(result)
-                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.OpenDirectory)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", **{result}**, {info.Log()})"));
+                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.OpenDirectory)}[{Interlocked.Read(ref pendingFiles)}] **{result}** (\"{fileName}\", {info.Log()})"));
         }
 
         internal void SetupCreateDirectory(string path)
@@ -706,7 +729,7 @@ namespace DokanNet.Tests
             operations
                 .Setup(d => d.CreateDirectory(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
                 .Returns(result)
-                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.CreateDirectory)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", **{result}**, {info.Log()})"));
+                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.CreateDirectory)}[{Interlocked.Read(ref pendingFiles)}] **{result}** (\"{fileName}\", {info.Log()})"));
         }
 
         internal void SetupDeleteDirectory(string path, bool recurse)
@@ -745,7 +768,7 @@ namespace DokanNet.Tests
                 .Setup(d => d.CreateFile(path, It.IsAny<FileAccess>(), It.IsAny<FileShare>(), It.IsAny<FileMode>(), It.IsAny<FileOptions>(), It.IsAny<FileAttributes>(), It.IsAny<DokanFileInfo>()))
                 .Returns(result)
                 .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions options, FileAttributes _attributes, DokanFileInfo info)
-                    => Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", **{result}** [{_access}], [{_share}], {_mode}, [{options}], [{_attributes}], {info.Log()})"));
+                    => Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Read(ref pendingFiles)}] **{result}** (\"{fileName}\", [{_access}], [{_share}], {_mode}, [{options}], [{_attributes}], {info.Log()})"));
         }
 
         internal void SetupCleanupFile(string path, object context = null, bool isDirectory = false, bool deleteOnClose = false)
@@ -910,6 +933,15 @@ namespace DokanNet.Tests
                 .Returns(DokanResult.Success)
                 .Callback((string oldName, string newName, bool _replace, DokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.MoveFile)}[{Interlocked.Increment(ref pendingFiles)}] (\"{oldName}\", \"{newName}\", {_replace}, {info.Log()})"));
+        }
+
+        internal void SetupMoveFileWithError(string path, string destinationPath, bool replace, DokanResult result)
+        {
+            operations
+                .Setup(d => d.MoveFile(path, destinationPath, replace, It.IsAny<DokanFileInfo>()))
+                .Returns(result)
+                .Callback((string oldName, string newName, bool _replace, DokanFileInfo info)
+                    => Trace($"{nameof(IDokanOperations.MoveFile)}[{Interlocked.Increment(ref pendingFiles)}] **{result}** (\"{oldName}\", \"{newName}\", {_replace}, {info.Log()})"));
         }
 
         internal void SetupSetAllocationSize(string path, long length)

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -642,13 +642,6 @@ namespace DokanNet.Tests
                 .Setup(d => d.CloseFile(RootName, It.IsAny<DokanFileInfo>()))
                 .Returns(DokanResult.Success)
                 .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.CloseFile)}[{Interlocked.Decrement(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
-
-            operations
-                .Setup(d => d.CreateFile(@"\Desktop.ini", ReadAccess, ReadWriteShare, readFileMode, readFileOptions, readFileAttributes, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
-                .Returns(DokanResult.FileNotFound);
-            operations
-                .Setup(d => d.CreateFile(@"\Autorun.inf", ReadAttributesAccess, ReadWriteShare, readFileMode, readFileOptions, readFileAttributes, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
-                .Returns(DokanResult.FileNotFound);
         }
 
         internal void SetupDiskFreeSpace(long freeBytesAvailable = 0, long totalNumberOfBytes = 0, long totalNumberOfFreeBytes = 0)
@@ -819,10 +812,8 @@ namespace DokanNet.Tests
                     info.Context = null;
                     Trace($"{nameof(IDokanOperations.Cleanup)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})");
                 });
-            operations
-                .Setup(d => d.CloseFile(path, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory && i.DeleteOnClose == deleteOnClose)))
-                .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.CloseFile)}[{Interlocked.Decrement(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
+
+            SetupCloseFile(path, context, isDirectory, deleteOnClose);
         }
 
         internal void SetupCloseFile(string path, object context = null, bool isDirectory = false, bool deleteOnClose = false)

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -516,6 +516,14 @@ namespace DokanNet.Tests
                     => Trace($"{nameof(IDokanOperations.FindFiles)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_files.Count}], {info.Log()})"));
         }
 
+        internal void SetupOpenDirectoryWithoutCleanup(string path)
+        {
+            operations
+                .Setup(d => d.OpenDirectory(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Returns(DokanResult.Success)
+                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.OpenDirectory)}-NoCleanup[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
+        }
+
         internal void SetupOpenDirectory(string path)
         {
             operations
@@ -530,14 +538,6 @@ namespace DokanNet.Tests
                 .Setup(d => d.CloseFile(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
                 .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.CloseFile)}[{Interlocked.Decrement(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
-        }
-
-        internal void SetupOpenDirectoryWithoutCleanup(string path)
-        {
-            operations
-                .Setup(d => d.OpenDirectory(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
-                .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.OpenDirectory)}-NoCleanup[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
         }
 
         internal void SetupOpenDirectoryWithError(string path, DokanResult result)
@@ -630,6 +630,18 @@ namespace DokanNet.Tests
                 .Returns(DokanResult.Success)
                 .Callback((string fileName, DokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FlushFileBuffers)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
+        }
+
+        internal void SetupLockUnlockFile(string path, long offset, long length)
+        {
+            operations
+                .Setup(d => d.LockFile(path, offset, length, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Returns(DokanResult.Success)
+                .Callback((string fileName, long _offset, long _length, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.LockFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {_offset}, {_length}, {info.Log()})"));
+            operations
+                .Setup(d => d.UnlockFile(path, offset, length, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Returns(DokanResult.Success)
+                .Callback((string fileName, long _offset, long _length, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.UnlockFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {_offset}, {_length}, {info.Log()})"));
         }
 
         internal void SetupReadFile(string path, byte[] buffer, int bytesRead)

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -50,6 +50,13 @@ namespace DokanNet.Tests
             public DokanResult DeleteFile(string fileName, DokanFileInfo info)
                 => TryExecute(() => Target.DeleteFile(fileName, info));
 
+            public DokanResult EnumerateNamedStreams(string fileName, IntPtr enumContext, out string streamName, out long streamSize, DokanFileInfo info)
+            {
+                streamName = string.Empty;
+                streamSize = 0;
+                return DokanResult.NotImplemented;
+            }
+
             public DokanResult FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info)
                 => Target.FindFiles(fileName, out files, info);
 

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -31,6 +31,9 @@ namespace DokanNet.Tests
                 Justification = "Explicit Exception handler")]
             private DokanResult TryExecute(DokanFileInfo info, Func<DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id)
+                    return DokanResult.AccessDenied;
+
                 try
                 {
                     return func(info);
@@ -48,6 +51,9 @@ namespace DokanNet.Tests
                 Justification = "Explicit Exception handler")]
             private DokanResult TryExecute(string fileName, DokanFileInfo info, Func<string, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id)
+                    return DokanResult.AccessDenied;
+
                 try
                 {
                     return func(fileName, info);
@@ -65,6 +71,9 @@ namespace DokanNet.Tests
                 Justification = "Explicit Exception handler")]
             private DokanResult TryExecute<T>(string fileName, T arg, DokanFileInfo info, Func<string, T, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id)
+                    return DokanResult.AccessDenied;
+
                 try
                 {
                     return func(fileName, arg, info);
@@ -82,6 +91,9 @@ namespace DokanNet.Tests
                 Justification = "Explicit Exception handler")]
             private DokanResult TryExecute<T1, T2>(string fileName, T1 arg1, T2 arg2, DokanFileInfo info, Func<string, T1, T2, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id)
+                    return DokanResult.AccessDenied;
+
                 try
                 {
                     return func(fileName, arg1, arg2, info);
@@ -99,6 +111,9 @@ namespace DokanNet.Tests
                 Justification = "Explicit Exception handler")]
             private DokanResult TryExecute<T1, T2, T3>(string fileName, T1 arg1, T2 arg2, T3 arg3, DokanFileInfo info, Func<string, T1, T2, T3, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id)
+                    return DokanResult.AccessDenied;
+
                 try
                 {
                     return func(fileName, arg1, arg2, arg3, info);
@@ -114,18 +129,23 @@ namespace DokanNet.Tests
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private DokanResult TryExecute<TOut>(string fileName, out TOut outParameter, DokanFileInfo info, FuncOut2<string, TOut, DokanFileInfo, DokanResult> func, string funcName)
+            private DokanResult TryExecute<TOut>(string fileName, out TOut argOut, DokanFileInfo info, FuncOut2<string, TOut, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id) {
+                    argOut = default(TOut);
+                    return DokanResult.AccessDenied;
+                }
+
                 try
                 {
-                    return func(fileName, out outParameter, info);
+                    return func(fileName, out argOut, info);
                 }
                 catch (Exception ex)
                 {
                     Trace($"{funcName} (\"{fileName}\", {info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
                     if (ex is MockException)
                         HasUnmatchedInvocations = true;
-                    outParameter = default(TOut);
+                    argOut = default(TOut);
                     return DokanResult.ExceptionInService;
                 }
             }
@@ -134,6 +154,11 @@ namespace DokanNet.Tests
                 Justification = "Explicit Exception handler")]
             private DokanResult TryExecute<TOut, TIn>(string fileName, out TOut argOut, TIn argIn, DokanFileInfo info, FuncOut2<string, TOut, TIn, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id) {
+                    argOut = default(TOut);
+                    return DokanResult.AccessDenied;
+                }
+
                 try
                 {
                     return func(fileName, out argOut, argIn, info);
@@ -152,6 +177,11 @@ namespace DokanNet.Tests
                 Justification = "Explicit Exception handler")]
             private DokanResult TryExecute<TIn1, TOut, TIn2>(string fileName, TIn1 argIn1, out TOut argOut, TIn2 argIn2, DokanFileInfo info, FuncOut3<string, TIn1, TOut, TIn2, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id) {
+                    argOut = default(TOut);
+                    return DokanResult.AccessDenied;
+                }
+
                 try
                 {
                     return func(fileName, argIn1, out argOut, argIn2, info);
@@ -168,20 +198,27 @@ namespace DokanNet.Tests
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
                 Justification = "Explicit Exception handler")]
-            private DokanResult TryExecute<TOut1, TOut2, TOut3>(out TOut1 outParameter1, out TOut2 outParameter2, out TOut3 outParameter3, DokanFileInfo info, FuncOut123<TOut1, TOut2, TOut3, DokanFileInfo, DokanResult> func, string funcName)
+            private DokanResult TryExecute<TOut1, TOut2, TOut3>(out TOut1 argOut1, out TOut2 argOut2, out TOut3 argOut3, DokanFileInfo info, FuncOut123<TOut1, TOut2, TOut3, DokanFileInfo, DokanResult> func, string funcName)
             {
+                if (info.ProcessId != System.Diagnostics.Process.GetCurrentProcess().Id) {
+                    argOut1 = default(TOut1);
+                    argOut2 = default(TOut2);
+                    argOut3 = default(TOut3);
+                    return DokanResult.AccessDenied;
+                }
+
                 try
                 {
-                    return func(out outParameter1, out outParameter2, out outParameter3, info);
+                    return func(out argOut1, out argOut2, out argOut3, info);
                 }
                 catch (Exception ex)
                 {
                     Trace($"{funcName} ({info.Log()}) -> **{ex.GetType().Name}**: {ex.Message}");
                     if (ex is MockException)
                         HasUnmatchedInvocations = true;
-                    outParameter1 = default(TOut1);
-                    outParameter2 = default(TOut2);
-                    outParameter3 = default(TOut3);
+                    argOut1 = default(TOut1);
+                    argOut2 = default(TOut2);
+                    argOut3 = default(TOut3);
                     return DokanResult.ExceptionInService;
                 }
             }
@@ -782,6 +819,14 @@ namespace DokanNet.Tests
                     info.Context = null;
                     Trace($"{nameof(IDokanOperations.Cleanup)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})");
                 });
+            operations
+                .Setup(d => d.CloseFile(path, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory && i.DeleteOnClose == deleteOnClose)))
+                .Returns(DokanResult.Success)
+                .Callback((string fileName, DokanFileInfo info) => Trace($"{nameof(IDokanOperations.CloseFile)}[{Interlocked.Decrement(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
+        }
+
+        internal void SetupCloseFile(string path, object context = null, bool isDirectory = false, bool deleteOnClose = false)
+        {
             operations
                 .Setup(d => d.CloseFile(path, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory && i.DeleteOnClose == deleteOnClose)))
                 .Returns(DokanResult.Success)

--- a/DokanNet.Tests/DriveInfoTest.cs
+++ b/DokanNet.Tests/DriveInfoTest.cs
@@ -18,7 +18,9 @@ namespace DokanNet.Tests
         [TestCleanup]
         public void Cleanup()
         {
-            DokanOperationsFixture.ClearInstance();
+            bool hasUnmatchedInvocations = false;
+            DokanOperationsFixture.ClearInstance(out hasUnmatchedInvocations);
+            Assert.IsFalse(hasUnmatchedInvocations, "Found Mock invocations without corresponding setups");
         }
 
         [TestMethod, TestCategory(TestCategories.Success)]

--- a/DokanNet.Tests/DriveInfoTest.cs
+++ b/DokanNet.Tests/DriveInfoTest.cs
@@ -46,7 +46,7 @@ namespace DokanNet.Tests
 #endif
         }
 
-        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Manual)]
+        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Success)]
         public void GetDriveFormat_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;
@@ -176,7 +176,7 @@ namespace DokanNet.Tests
 #endif
         }
 
-        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Manual)]
+        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Success)]
         public void GetVolumeLabel_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;

--- a/DokanNet.Tests/DriveInfoTest.cs
+++ b/DokanNet.Tests/DriveInfoTest.cs
@@ -46,7 +46,7 @@ namespace DokanNet.Tests
 #endif
         }
 
-        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Success)]
+        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Manual)]
         public void GetDriveFormat_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;
@@ -176,7 +176,7 @@ namespace DokanNet.Tests
 #endif
         }
 
-        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Success)]
+        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Manual)]
         public void GetVolumeLabel_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;

--- a/DokanNet.Tests/FileInfoTest.cs
+++ b/DokanNet.Tests/FileInfoTest.cs
@@ -784,7 +784,7 @@ namespace DokanNet.Tests
             var fixture = DokanOperationsFixture.Instance;
 
             string path = DokanOperationsFixture.FileName.AsRootedPath();
-            string value = $"TestValue for test {nameof(OpenRead_CallsApiCorrectly)}";
+            string value = $"TestValue for test {nameof(OpenRead_WithDelay_CallsApiCorrectly)}";
 #if LOGONLY
             fixture.SetupAny();
 #else
@@ -956,7 +956,7 @@ namespace DokanNet.Tests
             var fixture = DokanOperationsFixture.Instance;
 
             string path = DokanOperationsFixture.FileName.AsRootedPath();
-            string value = $"TestValue for test {nameof(OpenWrite_CallsApiCorrectly)}";
+            string value = $"TestValue for test {nameof(OpenWrite_WithDelay_CallsApiCorrectly)}";
 #if LOGONLY
             fixture.SetupAny();
 #else
@@ -1045,6 +1045,39 @@ namespace DokanNet.Tests
 
 #if !LOGONLY
                 Assert.AreEqual(largeData.Length, stream.Position, "Unexpected write count");
+#endif
+            }
+
+#if !LOGONLY
+            fixture.VerifyAll();
+#endif
+        }
+
+        [TestMethod, TestCategory(TestCategories.Success)]
+        public void OpenWrite_WithFlush_CallsApiCorrectly()
+        {
+            var fixture = DokanOperationsFixture.Instance;
+
+            string path = DokanOperationsFixture.FileName.AsRootedPath();
+            string value = $"TestValue for test {nameof(OpenWrite_WithFlush_CallsApiCorrectly)}";
+#if LOGONLY
+            fixture.SetupAny();
+#else
+            fixture.SetupCreateFile(path, WriteAccess, WriteShare, FileMode.OpenOrCreate);
+            fixture.SetupWriteFile(path, Encoding.UTF8.GetBytes(value), value.Length);
+            fixture.SetupFlushFileBuffers(path);
+#endif
+
+            var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
+
+            using (var stream = sut.OpenWrite())
+            {
+                Assert.IsTrue(stream.CanWrite, "Stream should be writable");
+                stream.Write(Encoding.UTF8.GetBytes(value), 0, value.Length);
+                stream.Flush(true);
+
+#if !LOGONLY
+                Assert.AreEqual(value.Length, stream.Position, "Unexpected write count");
 #endif
             }
 

--- a/DokanNet.Tests/FileInfoTest.cs
+++ b/DokanNet.Tests/FileInfoTest.cs
@@ -442,9 +442,9 @@ namespace DokanNet.Tests
             // WARNING: This is probably an error in the Dokan driver!
             fixture.SetupOpenDirectoryWithoutCleanup(string.Empty);
             fixture.SetupMoveFile(path, destinationPath, false);
-            fixture.SetupCleanupFile(destinationPath);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCloseFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCleanupFile(destinationPath);
 #endif
 
             var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
@@ -472,9 +472,9 @@ namespace DokanNet.Tests
             fixture.SetupGetFileInformation(path, FileAttributes.Normal);
             fixture.SetupOpenDirectoryWithoutCleanup(DokanOperationsFixture.DestinationDirectoryName.AsRootedPath());
             fixture.SetupMoveFile(path, destinationPath, false);
-            fixture.SetupCleanupFile(destinationPath);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCloseFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCleanupFile(destinationPath);
 #endif
 
             var sut = new FileInfo(origin.AsDriveBasedPath());
@@ -1187,11 +1187,11 @@ namespace DokanNet.Tests
             fixture.SetupMoveFile(destinationPath, destinationBackupPath, true);
             fixture.SetupCleanupFile(destinationBackupPath);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationBackupPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCloseFile(destinationBackupPath, /* This call is probably redundant. */isDirectory: true);
             fixture.SetupMoveFile(path, destinationPath, true);
             fixture.SetupCleanupFile(destinationPath);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCloseFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
 #endif
 
             var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
@@ -1229,11 +1229,11 @@ namespace DokanNet.Tests
             fixture.SetupMoveFile(destinationPath, destinationBackupPath, true);
             fixture.SetupCleanupFile(destinationBackupPath);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationBackupPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCloseFile(destinationBackupPath, /* This call is probably redundant. */isDirectory: true);
             fixture.SetupMoveFile(path, destinationPath, true);
             fixture.SetupCleanupFile(destinationPath);
             // WARNING: This is probably an error in the Dokan driver!
-            fixture.SetupCleanupFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
+            fixture.SetupCloseFile(destinationPath, /* This call is probably redundant. */isDirectory: true);
 #endif
 
             var sut = new FileInfo(origin.AsDriveBasedPath());

--- a/DokanNet.Tests/FileInfoTest.cs
+++ b/DokanNet.Tests/FileInfoTest.cs
@@ -888,6 +888,42 @@ namespace DokanNet.Tests
         }
 
         [TestMethod, TestCategory(TestCategories.Success)]
+        public void OpenRead_WithLockingAndUnlocking_CallsApiCorrectly()
+        {
+            var fixture = DokanOperationsFixture.Instance;
+
+            string path = DokanOperationsFixture.FileName.AsRootedPath();
+            string value = $"TestValue for test {nameof(OpenRead_CallsApiCorrectly)}";
+#if LOGONLY
+            fixture.SetupAny();
+#else
+            fixture.SetupCreateFile(path, ReadAccess, ReadOnlyShare, FileMode.Open);
+            fixture.SetupReadFile(path, Encoding.UTF8.GetBytes(value), value.Length);
+            fixture.SetupLockUnlockFile(path, 0, value.Length);
+#endif
+
+            var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
+
+            using (var stream = sut.OpenRead())
+            {
+                Assert.IsTrue(stream.CanRead, "Stream should be readable");
+                var target = new byte[value.Length];
+                stream.Lock(0, target.Length);
+                int readBytes = stream.Read(target, 0, target.Length);
+                stream.Unlock(0, target.Length);
+
+#if !LOGONLY
+                Assert.AreEqual(value.Length, readBytes, "Unexpected read count");
+                Assert.AreEqual(value, Encoding.UTF8.GetString(target), "Unexpected result content");
+#endif
+            }
+
+#if !LOGONLY
+            fixture.VerifyAll();
+#endif
+        }
+
+        [TestMethod, TestCategory(TestCategories.Success)]
         public void OpenText_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;
@@ -1075,6 +1111,40 @@ namespace DokanNet.Tests
                 Assert.IsTrue(stream.CanWrite, "Stream should be writable");
                 stream.Write(Encoding.UTF8.GetBytes(value), 0, value.Length);
                 stream.Flush(true);
+
+#if !LOGONLY
+                Assert.AreEqual(value.Length, stream.Position, "Unexpected write count");
+#endif
+            }
+
+#if !LOGONLY
+            fixture.VerifyAll();
+#endif
+        }
+
+        [TestMethod, TestCategory(TestCategories.Success)]
+        public void OpenWrite_WithLockingAndUnlocking_CallsApiCorrectly()
+        {
+            var fixture = DokanOperationsFixture.Instance;
+
+            string path = DokanOperationsFixture.FileName.AsRootedPath();
+            string value = $"TestValue for test {nameof(OpenWrite_CallsApiCorrectly)}";
+#if LOGONLY
+            fixture.SetupAny();
+#else
+            fixture.SetupCreateFile(path, WriteAccess, WriteShare, FileMode.OpenOrCreate);
+            fixture.SetupWriteFile(path, Encoding.UTF8.GetBytes(value), value.Length);
+            fixture.SetupLockUnlockFile(path, 0, value.Length);
+#endif
+
+            var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
+
+            using (var stream = sut.OpenWrite())
+            {
+                Assert.IsTrue(stream.CanWrite, "Stream should be writable");
+                stream.Lock(0, value.Length);
+                stream.Write(Encoding.UTF8.GetBytes(value), 0, value.Length);
+                stream.Unlock(0, value.Length);
 
 #if !LOGONLY
                 Assert.AreEqual(value.Length, stream.Position, "Unexpected write count");

--- a/DokanNet.Tests/FileInfoTest.cs
+++ b/DokanNet.Tests/FileInfoTest.cs
@@ -526,6 +526,7 @@ namespace DokanNet.Tests
         {
             foreach (var access in accessModes)
             {
+                Console.WriteLine($"{nameof(info.Open)} {mode}/{access}");
                 using (var stream = info.Open(mode, access))
                 {
 #if !LOGONLY
@@ -554,7 +555,6 @@ namespace DokanNet.Tests
 #endif
                     }
                 }
-                Console.WriteLine($"{nameof(info.Open)} {mode}/{access}");
             }
         }
 

--- a/DokanNet.Tests/FileInfoTest.cs
+++ b/DokanNet.Tests/FileInfoTest.cs
@@ -43,7 +43,9 @@ namespace DokanNet.Tests
         [TestCleanup]
         public void Cleanup()
         {
-            DokanOperationsFixture.ClearInstance();
+            bool hasUnmatchedInvocations = false;
+            DokanOperationsFixture.ClearInstance(out hasUnmatchedInvocations);
+            Assert.IsFalse(hasUnmatchedInvocations, "Found Mock invocations without corresponding setups");
         }
 
         [TestMethod, TestCategory(TestCategories.Success)]
@@ -437,6 +439,7 @@ namespace DokanNet.Tests
 #else
             fixture.SetupCreateFileWithoutCleanup(path, MoveFromAccess, ReadWriteShare, FileMode.Open);
             fixture.SetupGetFileInformation(path, FileAttributes.Normal);
+            // WARNING: This is probably an error in the Dokan driver!
             fixture.SetupOpenDirectoryWithoutCleanup(string.Empty);
             fixture.SetupMoveFile(path, destinationPath, false);
             fixture.SetupCleanupFile(destinationPath);
@@ -514,7 +517,11 @@ namespace DokanNet.Tests
 #else
             fixture.SetupCreateFile(path, MoveFromAccess, ReadWriteShare, FileMode.Open);
             fixture.SetupGetFileInformation(path, FileAttributes.Normal);
-            fixture.SetupCreateFileWithError(destinationPath, DokanResult.FileExists);
+            fixture.SetupMoveFileWithError(path, destinationPath, false, DokanResult.AlreadyExists);
+            // WARNING: This is probably an error in the Dokan driver!
+            fixture.SetupOpenDirectoryWithoutCleanup(string.Empty);
+            // WARNING: This is probably an error in the Dokan driver!
+            fixture.SetupCleanupFile(destinationPath, isDirectory: true);
 #endif
 
             var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
@@ -1175,6 +1182,7 @@ namespace DokanNet.Tests
             fixture.SetupSetFileAttributes(path, FileAttributes.Normal);
             fixture.SetupSetFileTime(path);
             fixture.SetupGetVolumeInformation(DokanOperationsFixture.VOLUME_LABEL, DokanOperationsFixture.FILESYSTEM_NAME);
+            // WARNING: This is probably an error in the Dokan driver!
             fixture.SetupOpenDirectoryWithoutCleanup(string.Empty);
             fixture.SetupMoveFile(destinationPath, destinationBackupPath, true);
             fixture.SetupCleanupFile(destinationBackupPath);

--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -2,6 +2,7 @@ using DokanNet.Native;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
@@ -43,7 +44,7 @@ namespace DokanNet
             [MarshalAs(UnmanagedType.LPWStr)] string rawFileName, IntPtr rawFillFindData, // function pointer
             [MarshalAs(UnmanagedType.LPStruct), In/*, Out*/] DokanFileInfo rawFileInfo);
 
-        /*     public delegate int FindFilesWithPatternDelegate(
+        /*public delegate int FindFilesWithPatternDelegate(
             [MarshalAs(UnmanagedType.LPWStr)] string rawFileName,
             [MarshalAs(UnmanagedType.LPWStr)] string rawSearchPattern,
             IntPtr rawFillFindData, // function pointer
@@ -135,56 +136,62 @@ namespace DokanNet
 
         #endregion Delegates
 
-        private readonly IDokanOperations _operations;
+        private readonly IDokanOperations operations;
 
-        private readonly uint _serialNumber;
+        private readonly uint serialNumber;
 
         public DokanOperationProxy(IDokanOperations operations)
         {
-            _operations = operations;
-            _serialNumber = (uint)_operations.GetHashCode();
+            this.operations = operations;
+            serialNumber = (uint)this.operations.GetHashCode();
         }
 
-        private void DbgPrint(string message)
+        private void Trace(string message)
         {
-#if DEBUG
+#if TRACE
             Console.WriteLine(message);
 #endif
         }
 
-        public int CreateFileProxy(string rawFileName, uint rawAccessMode,
-                                   uint rawShare, uint rawCreationDisposition, uint rawFlagsAndAttributes,
+        private string ToTrace(DokanFileInfo info)
+        {
+            var context = info.Context != null ? info.Context.GetType().Name : "<null>";
+
+            return string.Format(CultureInfo.InvariantCulture, "{{{0}, {1}, {2}, {3}, {4}, #{5}, {6}, {7}}}",
+                context, info.DeleteOnClose, info.IsDirectory, info.NoCache, info.PagingIo, info.ProcessId, info.SynchronousIo, info.WriteToEndOfFile);
+        }
+
+        public int CreateFileProxy(string rawFileName,
+                                   uint rawAccessMode, uint rawShare, uint rawCreationDisposition, uint rawFlagsAndAttributes,
                                    DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nCreateFileProxy : " + rawFileName);
-                DbgPrint("\tCreationDisposition\t" + (FileMode)rawCreationDisposition);
-                DbgPrint("\tFileAccess\t" + (FileAccess)rawAccessMode);
-                DbgPrint("\tFileShare\t" + (FileShare)rawShare);
-                DbgPrint("\tFileOptions\t" + (FileOptions)(rawFlagsAndAttributes & 0xffffc000));
-                DbgPrint("\tFileAttributes\t" + (FileAttributes)(rawFlagsAndAttributes & 0x3fff));
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nCreateFileProxy : " + rawFileName);
+                Trace("\tCreationDisposition\t" + (FileMode)rawCreationDisposition);
+                Trace("\tFileAccess\t" + (FileAccess)rawAccessMode);
+                Trace("\tFileShare\t" + (FileShare)rawShare);
+                Trace("\tFileOptions\t" + (FileOptions)(rawFlagsAndAttributes & 0xffffc000));
+                Trace("\tFileAttributes\t" + (FileAttributes)(rawFlagsAndAttributes & 0x3fff));
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.CreateFile(rawFileName, (FileAccess)rawAccessMode, (FileShare)rawShare,
+                DokanResult result = operations.CreateFile(rawFileName,
+                                                    (FileAccess)rawAccessMode,
+                                                    (FileShare)rawShare,
                                                     (FileMode)rawCreationDisposition,
-                                                    (FileOptions)(rawFlagsAndAttributes & 0xffffc000), //& 0xffffc000
-                                                    (FileAttributes)(rawFlagsAndAttributes & 0x3fff), rawFileInfo);
-                //& 0x3ffflower 14 bits i think are file atributes and rest are file options WRITE_TROUGH etc.
+                                                    (FileOptions)(rawFlagsAndAttributes & 0xffffc000),
+                                                    (FileAttributes)(rawFlagsAndAttributes & 0x3fff),
+                                                    rawFileInfo);
 
-                DbgPrint("CreateFileProxy : " + rawFileName + " Return : " + result);
+                Trace("CreateFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("CreateFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("CreateFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -195,24 +202,20 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nOpenDirectoryProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nOpenDirectoryProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.OpenDirectory(rawFileName, rawFileInfo);
+                DokanResult result = operations.OpenDirectory(rawFileName, rawFileInfo);
 
-                DbgPrint("OpenDirectoryProxy : " + rawFileName + " Return : " + result);
+                Trace("OpenDirectoryProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("OpenDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.Error;
-#endif
+                Trace("OpenDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -223,52 +226,44 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nCreateDirectoryProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nCreateDirectoryProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.CreateDirectory(rawFileName, rawFileInfo);
+                DokanResult result = operations.CreateDirectory(rawFileName, rawFileInfo);
 
-                DbgPrint("CreateDirectoryProxy : " + rawFileName + " Return : " + result);
+                Trace("CreateDirectoryProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("CreateDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.Error;
-#endif
+                Trace("CreateDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
         ////
 
         public int CleanupProxy(string rawFileName,
-                               DokanFileInfo rawFileInfo)
+                                DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nCleanupProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nCleanupProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.Cleanup(rawFileName, rawFileInfo);
+                DokanResult result = operations.Cleanup(rawFileName, rawFileInfo);
 
-                DbgPrint("CleanupProxy : " + rawFileName + " Return : " + result);
+                Trace("CleanupProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("CleanupProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("CleanupProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -279,89 +274,74 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nCloseFileProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nCloseFileProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.CloseFile(rawFileName, rawFileInfo);
+                DokanResult result = operations.CloseFile(rawFileName, rawFileInfo);
 
-                DbgPrint("CloseFileProxy : " + rawFileName + " Return : " + result);
+                Trace("CloseFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("CloseFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("CloseFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
         ////
 
-        public int ReadFileProxy(string rawFileName, byte[] rawBuffer,
-                                 uint rawBufferLength, ref int rawReadLength, long rawOffset,
+        public int ReadFileProxy(string rawFileName,
+                                 byte[] rawBuffer, uint rawBufferLength, ref int rawReadLength, long rawOffset,
                                  DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nReadFileProxy : " + rawFileName);
-                DbgPrint("\tBufferLength\t" + rawBufferLength);
-                DbgPrint("\tOffset\t" + rawOffset);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nReadFileProxy : " + rawFileName);
+                Trace("\tBufferLength\t" + rawBufferLength);
+                Trace("\tOffset\t" + rawOffset);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.ReadFile(rawFileName, rawBuffer, out rawReadLength, rawOffset,
-                                                  rawFileInfo);
+                DokanResult result = operations.ReadFile(rawFileName, rawBuffer, out rawReadLength, rawOffset, rawFileInfo);
 
-                DbgPrint("ReadFileProxy : " + rawFileName + " Return : " + result + " ReadLength : " + rawReadLength);
+                Trace("ReadFileProxy : " + rawFileName + " Return : " + result + " ReadLength : " + rawReadLength);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("ReadFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("ReadFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
         ////
 
-        public int WriteFileProxy(string rawFileName, byte[] rawBuffer,
-                                  uint rawNumberOfBytesToWrite, ref int rawNumberOfBytesWritten, long rawOffset,
+        public int WriteFileProxy(string rawFileName,
+                                  byte[] rawBuffer, uint rawNumberOfBytesToWrite, ref int rawNumberOfBytesWritten, long rawOffset,
                                   DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nWriteFileProxy : " + rawFileName);
-                DbgPrint("\tNumberOfBytesToWrite\t" + rawNumberOfBytesToWrite);
-                DbgPrint("\tOffset\t" + rawOffset);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nWriteFileProxy : " + rawFileName);
+                Trace("\tNumberOfBytesToWrite\t" + rawNumberOfBytesToWrite);
+                Trace("\tOffset\t" + rawOffset);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.WriteFile(rawFileName, rawBuffer,
-                                                   out rawNumberOfBytesWritten, rawOffset,
-                                                   rawFileInfo);
+                DokanResult result = operations.WriteFile(rawFileName, rawBuffer, out rawNumberOfBytesWritten, rawOffset, rawFileInfo);
 
-                DbgPrint("WriteFileProxy : " + rawFileName + " Return : " + result + " NumberOfBytesWritten : " + rawNumberOfBytesWritten);
+                Trace("WriteFileProxy : " + rawFileName + " Return : " + result + " NumberOfBytesWritten : " + rawNumberOfBytesWritten);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("WriteFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("WriteFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -372,24 +352,20 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nFlushFileBuffersProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nFlushFileBuffersProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.FlushFileBuffers(rawFileName, rawFileInfo);
+                DokanResult result = operations.FlushFileBuffers(rawFileName, rawFileInfo);
 
-                DbgPrint("FlushFileBuffersProxy : " + rawFileName + " Return : " + result);
+                Trace("FlushFileBuffersProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("FlushFileBuffersProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("FlushFileBuffersProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -402,20 +378,20 @@ namespace DokanNet
             FileInformation fi;
             try
             {
-                DbgPrint("\nGetFileInformationProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nGetFileInformationProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.GetFileInformation(rawFileName, out fi, rawFileInfo);
+                DokanResult result = operations.GetFileInformation(rawFileName, out fi, rawFileInfo);
 
                 if (result == DokanResult.Success)
                 {
                     Debug.Assert(fi.FileName != null);
-                    DbgPrint("\tFileName\t" + fi.FileName);
-                    DbgPrint("\tAttributes\t" + fi.Attributes);
-                    DbgPrint("\tCreationTime\t" + fi.CreationTime);
-                    DbgPrint("\tLastAccessTime\t" + fi.LastAccessTime);
-                    DbgPrint("\tLastWriteTime\t" + fi.LastWriteTime);
-                    DbgPrint("\tLength\t" + fi.Length);
+                    Trace("\tFileName\t" + fi.FileName);
+                    Trace("\tAttributes\t" + fi.Attributes);
+                    Trace("\tCreationTime\t" + fi.CreationTime);
+                    Trace("\tLastAccessTime\t" + fi.LastAccessTime);
+                    Trace("\tLastWriteTime\t" + fi.LastWriteTime);
+                    Trace("\tLength\t" + fi.Length);
 
                     rawHandleFileInformation.dwFileAttributes = (uint)fi.Attributes /* + FILE_ATTRIBUTE_VIRTUAL*/;
 
@@ -431,7 +407,7 @@ namespace DokanNet
                     rawHandleFileInformation.ftLastWriteTime.dwHighDateTime = (int)(mtime >> 32);
                     rawHandleFileInformation.ftLastWriteTime.dwLowDateTime = (int)(mtime & 0xffffffff);
 
-                    rawHandleFileInformation.dwVolumeSerialNumber = _serialNumber;
+                    rawHandleFileInformation.dwVolumeSerialNumber = serialNumber;
 
                     rawHandleFileInformation.nFileSizeLow = (uint)(fi.Length & 0xffffffff);
                     rawHandleFileInformation.nFileSizeHigh = (uint)(fi.Length >> 32);
@@ -440,75 +416,64 @@ namespace DokanNet
                     rawHandleFileInformation.nFileIndexLow = (uint)fi.FileName.GetHashCode();
                 }
 
-                DbgPrint("GetFileInformationProxy : " + rawFileName + " Return : " + result);
+                Trace("GetFileInformationProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("GetFileInformationProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("GetFileInformationProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
         ////
 
-        public int FindFilesProxy(string rawFileName, IntPtr rawFillFindData,
-                                  // function pointer
+        public int FindFilesProxy(string rawFileName,
+                                  IntPtr rawFillFindData,
                                   DokanFileInfo rawFileInfo)
         {
             try
             {
                 IList<FileInformation> files;
 
-                DbgPrint("\nFindFilesProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nFindFilesProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.FindFiles(rawFileName, out files, rawFileInfo);
+                DokanResult result = operations.FindFiles(rawFileName, out files, rawFileInfo);
 
                 Debug.Assert(files != null);
                 if (result == DokanResult.Success && files.Count != 0)
                 {
-#if DEBUG
                     foreach (FileInformation fi in files)
                     {
-                        DbgPrint("\n\tFileName\t" + fi.FileName);
-                        DbgPrint("\tAttributes\t" + fi.Attributes);
-                        DbgPrint("\tCreationTime\t" + fi.CreationTime);
-                        DbgPrint("\tLastAccessTime\t" + fi.LastAccessTime);
-                        DbgPrint("\tLastWriteTime\t" + fi.LastWriteTime);
-                        DbgPrint("\tLength\t" + fi.Length);
+                        Trace("\n\tFileName\t" + fi.FileName);
+                        Trace("\tAttributes\t" + fi.Attributes);
+                        Trace("\tCreationTime\t" + fi.CreationTime);
+                        Trace("\tLastAccessTime\t" + fi.LastAccessTime);
+                        Trace("\tLastWriteTime\t" + fi.LastWriteTime);
+                        Trace("\tLength\t" + fi.Length);
                     }
-#endif
 
-                    var fill =
+                var fill =
                    (FILL_FIND_DATA)Marshal.GetDelegateForFunctionPointer(rawFillFindData, typeof(FILL_FIND_DATA));
-                    // Used a single entry call to speed up the "enumeration" of the list
+                    // used a single entry call to speed up the "enumeration" of the list
                     for (int index = 0; index < files.Count; index++)
-
                     {
                         Addto(fill, rawFileInfo, files[index]);
                     }
                 }
 
-                DbgPrint("FindFilesProxy : " + rawFileName + " Return : " + result);
+                Trace("FindFilesProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("FindFilesProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.InvalidHandle;
-#endif
+                Trace("FindFilesProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -547,30 +512,27 @@ namespace DokanNet
 
         ////
 
-        public int SetEndOfFileProxy(string rawFileName, long rawByteOffset,
+        public int SetEndOfFileProxy(string rawFileName,
+                                     long rawByteOffset,
                                      DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nSetEndOfFileProxy : " + rawFileName);
-                DbgPrint("\tByteOffset\t" + rawByteOffset);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nSetEndOfFileProxy : " + rawFileName);
+                Trace("\tByteOffset\t" + rawByteOffset);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.SetEndOfFile(rawFileName, rawByteOffset, rawFileInfo);
+                DokanResult result = operations.SetEndOfFile(rawFileName, rawByteOffset, rawFileInfo);
 
-                DbgPrint("SetEndOfFileProxy : " + rawFileName + " Return : " + result);
+                Trace("SetEndOfFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("SetEndOfFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("SetEndOfFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -579,54 +541,47 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nSetAllocationSizeProxy : " + rawFileName);
-                DbgPrint("\tLength\t" + rawLength);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nSetAllocationSizeProxy : " + rawFileName);
+                Trace("\tLength\t" + rawLength);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.SetAllocationSize(rawFileName, rawLength, rawFileInfo);
+                DokanResult result = operations.SetAllocationSize(rawFileName, rawLength, rawFileInfo);
 
-                DbgPrint("SetAllocationSizeProxy : " + rawFileName + " Return : " + result);
+                Trace("SetAllocationSizeProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("SetAllocationSizeProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("SetAllocationSizeProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
         ////
 
-        public int SetFileAttributesProxy(string rawFileName, uint rawAttributes,
+        public int SetFileAttributesProxy(string rawFileName,
+                                          uint rawAttributes,
                                           DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nSetFileAttributesProxy : " + rawFileName);
-                DbgPrint("\tAttributes\t" + (FileAttributes)rawAttributes);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nSetFileAttributesProxy : " + rawFileName);
+                Trace("\tAttributes\t" + (FileAttributes)rawAttributes);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.SetFileAttributes(rawFileName, (FileAttributes)rawAttributes, rawFileInfo);
+                DokanResult result = operations.SetFileAttributes(rawFileName, (FileAttributes)rawAttributes, rawFileInfo);
 
-                DbgPrint("SetFileAttributesProxy : " + rawFileName + " Return : " + result);
+                Trace("SetFileAttributesProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("SetFileAttributesProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("SetFileAttributesProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -648,27 +603,23 @@ namespace DokanNet
 
             try
             {
-                DbgPrint("\nSetFileTimeProxy : " + rawFileName);
-                DbgPrint("\tCreateTime\t" + ctime);
-                DbgPrint("\tAccessTime\t" + atime);
-                DbgPrint("\tWriteTime\t" + mtime);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nSetFileTimeProxy : " + rawFileName);
+                Trace("\tCreateTime\t" + ctime);
+                Trace("\tAccessTime\t" + atime);
+                Trace("\tWriteTime\t" + mtime);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.SetFileTime(rawFileName, ctime, atime, mtime, rawFileInfo);
+                DokanResult result = operations.SetFileTime(rawFileName, ctime, atime, mtime, rawFileInfo);
 
-                DbgPrint("SetFileTimeProxy : " + rawFileName + " Return : " + result);
+                Trace("SetFileTimeProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("SetFileTimeProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("SetFileTimeProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -679,24 +630,20 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nDeleteFileProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nDeleteFileProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.DeleteFile(rawFileName, rawFileInfo);
+                DokanResult result = operations.DeleteFile(rawFileName, rawFileInfo);
 
-                DbgPrint("DeleteFileProxy : " + rawFileName + " Return : " + result);
+                Trace("DeleteFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("DeleteFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("DeleteFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -707,24 +654,20 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nDeleteDirectoryProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nDeleteDirectoryProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.DeleteDirectory(rawFileName, rawFileInfo);
+                DokanResult result = operations.DeleteDirectory(rawFileName, rawFileInfo);
 
-                DbgPrint("DeleteDirectoryProxy : " + rawFileName + " Return : " + result);
+                Trace("DeleteDirectoryProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("DeleteDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("DeleteDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -736,27 +679,22 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nMoveFileProxy : " + rawFileName);
-                DbgPrint("\tNewFileName\t" + rawNewFileName);
-                DbgPrint("\tReplaceIfExisting\t" + rawReplaceIfExisting);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nMoveFileProxy : " + rawFileName);
+                Trace("\tNewFileName\t" + rawNewFileName);
+                Trace("\tReplaceIfExisting\t" + rawReplaceIfExisting);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.MoveFile(rawFileName, rawNewFileName, rawReplaceIfExisting,
-                                                  rawFileInfo);
+                DokanResult result = operations.MoveFile(rawFileName, rawNewFileName, rawReplaceIfExisting, rawFileInfo);
 
-                DbgPrint("MoveFileProxy : " + rawFileName + " Return : " + result);
+                Trace("MoveFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("MoveFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("MoveFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -768,26 +706,22 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nLockFileProxy : " + rawFileName);
-                DbgPrint("\tByteOffset\t" + rawByteOffset);
-                DbgPrint("\tLength\t" + rawLength);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nLockFileProxy : " + rawFileName);
+                Trace("\tByteOffset\t" + rawByteOffset);
+                Trace("\tLength\t" + rawLength);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.LockFile(rawFileName, rawByteOffset, rawLength, rawFileInfo);
+                DokanResult result = operations.LockFile(rawFileName, rawByteOffset, rawLength, rawFileInfo);
 
-                DbgPrint("LockFileProxy : " + rawFileName + " Return : " + result);
+                Trace("LockFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("LockFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("LockFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -799,26 +733,22 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nUnlockFileProxy : " + rawFileName);
-                DbgPrint("\tByteOffset\t" + rawByteOffset);
-                DbgPrint("\tLength\t" + rawLength);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nUnlockFileProxy : " + rawFileName);
+                Trace("\tByteOffset\t" + rawByteOffset);
+                Trace("\tLength\t" + rawLength);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.UnlockFile(rawFileName, rawByteOffset, rawLength, rawFileInfo);
+                DokanResult result = operations.UnlockFile(rawFileName, rawByteOffset, rawLength, rawFileInfo);
 
-                DbgPrint("UnlockFileProxy : " + rawFileName + " Return : " + result);
+                Trace("UnlockFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("UnlockFileProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("UnlockFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -829,47 +759,41 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nGetDiskFreeSpaceProxy");
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nGetDiskFreeSpaceProxy");
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.GetDiskFreeSpace(out rawFreeBytesAvailable, out rawTotalNumberOfBytes,
-                                                          out rawTotalNumberOfFreeBytes,
-                                                          rawFileInfo);
+                DokanResult result = operations.GetDiskFreeSpace(out rawFreeBytesAvailable, out rawTotalNumberOfBytes, out rawTotalNumberOfFreeBytes, rawFileInfo);
 
-                DbgPrint("\tFreeBytesAvailable\t" + rawFreeBytesAvailable);
-                DbgPrint("\tTotalNumberOfBytes\t" + rawTotalNumberOfBytes);
-                DbgPrint("\tTotalNumberOfFreeBytes\t" + rawTotalNumberOfFreeBytes);
-                DbgPrint("GetDiskFreeSpaceProxy Return : " + result);
+                Trace("\tFreeBytesAvailable\t" + rawFreeBytesAvailable);
+                Trace("\tTotalNumberOfBytes\t" + rawTotalNumberOfBytes);
+                Trace("\tTotalNumberOfFreeBytes\t" + rawTotalNumberOfFreeBytes);
+                Trace("GetDiskFreeSpaceProxy Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("GetDiskFreeSpaceProxy Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("GetDiskFreeSpaceProxy Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
-        public int GetVolumeInformationProxy(StringBuilder rawVolumeNameBuffer, uint rawVolumeNameSize, ref uint rawVolumeSerialNumber,
-                                             ref uint rawMaximumComponentLength, ref FileSystemFeatures rawFileSystemFlags,
+        public int GetVolumeInformationProxy(StringBuilder rawVolumeNameBuffer, uint rawVolumeNameSize,
+                                             ref uint rawVolumeSerialNumber, ref uint rawMaximumComponentLength, ref FileSystemFeatures rawFileSystemFlags,
                                              StringBuilder rawFileSystemNameBuffer, uint rawFileSystemNameSize,
                                              DokanFileInfo rawFileInfo)
         {
             rawMaximumComponentLength = 256;
-            rawVolumeSerialNumber = _serialNumber;
+            rawVolumeSerialNumber = serialNumber;
             string label;
             string name;
             try
             {
-                DbgPrint("\nGetVolumeInformationProxy");
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nGetVolumeInformationProxy");
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.GetVolumeInformation(out label, out rawFileSystemFlags, out name, rawFileInfo);
+                DokanResult result = operations.GetVolumeInformation(out label, out rawFileSystemFlags, out name, rawFileInfo);
 
                 if (result == DokanResult.Success)
                 {
@@ -878,25 +802,21 @@ namespace DokanNet
                     rawVolumeNameBuffer.Append(label);
                     rawFileSystemNameBuffer.Append(name);
 
-                    DbgPrint("\tVolumeNameBuffer\t" + rawVolumeNameBuffer);
-                    DbgPrint("\tFileSystemNameBuffer\t" + rawFileSystemNameBuffer);
-                    DbgPrint("\tVolumeSerialNumber\t" + rawVolumeSerialNumber);
-                    DbgPrint("\tFileSystemFlags\t" + rawFileSystemFlags);
+                    Trace("\tVolumeNameBuffer\t" + rawVolumeNameBuffer);
+                    Trace("\tFileSystemNameBuffer\t" + rawFileSystemNameBuffer);
+                    Trace("\tVolumeSerialNumber\t" + rawVolumeSerialNumber);
+                    Trace("\tFileSystemFlags\t" + rawFileSystemFlags);
                 }
 
-                DbgPrint("GetVolumeInformationProxy Return : " + result);
+                Trace("GetVolumeInformationProxy Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("GetVolumeInformationProxy Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("GetVolumeInformationProxy Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -904,24 +824,20 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nUnmountProxy");
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nUnmountProxy");
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.Unmount(rawFileInfo);
+                DokanResult result = operations.Unmount(rawFileInfo);
 
-                DbgPrint("UnmountProxy Return : " + result);
+                Trace("UnmountProxy Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("UnmountProxy Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("UnmountProxy Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -956,15 +872,15 @@ namespace DokanNet
             }
             try
             {
-                DbgPrint("\nGetFileSecurityProxy : " + rawFileName);
-                DbgPrint("\tFileSystemSecurity\t" + sect);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nGetFileSecurityProxy : " + rawFileName);
+                Trace("\tFileSystemSecurity\t" + sect);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.GetFileSecurity(rawFileName, out sec, sect, rawFileInfo);
+                DokanResult result = operations.GetFileSecurity(rawFileName, out sec, sect, rawFileInfo);
                 if (result == DokanResult.Success /*&& sec != null*/)
                 {
                     Debug.Assert(sec != null);
-                    DbgPrint("\tFileSystemSecurity Result : " + sec);
+                    Trace("\tFileSystemSecurity Result : " + sec);
                     var buffer = sec.GetSecurityDescriptorBinaryForm();
                     rawSecurityDescriptorLengthNeeded = (uint)buffer.Length;
                     if (buffer.Length > rawSecurityDescriptorLength)
@@ -973,24 +889,20 @@ namespace DokanNet
                     Marshal.Copy(buffer, 0, rawSecurityDescriptor, buffer.Length);
                 }
 
-                DbgPrint("GetFileSecurityProxy : " + rawFileName + " Return : " + result);
+                Trace("GetFileSecurityProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("GetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("GetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
-        public int SetFileSecurityProxy(string rawFileName, ref SECURITY_INFORMATION rawSecurityInformation,
-                                        IntPtr rawSecurityDescriptor, uint rawSecurityDescriptorLength,
+        public int SetFileSecurityProxy(string rawFileName,
+                                        ref SECURITY_INFORMATION rawSecurityInformation, IntPtr rawSecurityDescriptor, uint rawSecurityDescriptorLength,
                                         DokanFileInfo rawFileInfo)
         {
             var sect = AccessControlSections.None;
@@ -1021,26 +933,22 @@ namespace DokanNet
                 var sec = rawFileInfo.IsDirectory ? (FileSystemSecurity)new DirectorySecurity() : new FileSecurity();
                 sec.SetSecurityDescriptorBinaryForm(buffer);
 
-                DbgPrint("\nSetFileSecurityProxy : " + rawFileName);
-                DbgPrint("\tAccessControlSections\t" + sect);
-                DbgPrint("\tFileSystemSecurity\t" + sec);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\nSetFileSecurityProxy : " + rawFileName);
+                Trace("\tAccessControlSections\t" + sect);
+                Trace("\tFileSystemSecurity\t" + sec);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
-                DokanResult result = _operations.SetFileSecurity(rawFileName, sec, sect, rawFileInfo);
+                DokanResult result = operations.SetFileSecurity(rawFileName, sec, sect, rawFileInfo);
 
-                DbgPrint("SetFileSecurityProxy : " + rawFileName + " Return : " + result);
+                Trace("SetFileSecurityProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("SetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("SetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 
@@ -1052,30 +960,26 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\tEnumerateNamedStreamsProxy : " + rawFileName);
-                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+                Trace("\tEnumerateNamedStreamsProxy : " + rawFileName);
+                Trace("\tContext\t" + ToTrace(rawFileInfo));
 
                 string name;
-                DokanResult result = _operations.EnumerateNamedStreams(rawFileName, rawEnumContext, out name, out rawStreamSize , rawFileInfo);
+                DokanResult result = operations.EnumerateNamedStreams(rawFileName, rawEnumContext, out name, out rawStreamSize, rawFileInfo);
                 if (result == DokanResult.Success)
                 {
                     rawStreamName.Append(name);
                     rawStreamNameLength = (uint)name.Length;
                 }
 
-                DbgPrint("EnumerateNamedStreamsProxy : " + rawFileName + " Return : " + result);
+                Trace("EnumerateNamedStreamsProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
             catch (Exception ex)
 #pragma warning restore 0168
             {
-#if DEBUG
-                DbgPrint("EnumerateNamedStreamsProxy : " + rawFileName + " Throw : " + ex.Message);
-                throw;
-#else
-                return (int)DokanResult.FileNotFound;
-#endif
+                Trace("EnumerateNamedStreamsProxy : " + rawFileName + " Throw : " + ex.Message);
+                return (int)DokanResult.ExceptionInService;
             }
         }
 

--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -53,9 +53,9 @@ namespace DokanNet
             [MarshalAs(UnmanagedType.LPWStr)] string rawFileName,
             [MarshalAs(UnmanagedType.LPStruct), In/*, Out*/] DokanFileInfo rawFileInfo);
 
-        public delegate int GetDiskFreeSpaceDelegate(ref long rawFreeBytesAvailable, ref long rawTotalNumberOfBytes,
-                                                     ref long rawTotalNumberOfFreeBytes,
-                                                     [MarshalAs(UnmanagedType.LPStruct), In] DokanFileInfo rawFileInfo);
+        public delegate int GetDiskFreeSpaceDelegate(
+            ref long rawFreeBytesAvailable, ref long rawTotalNumberOfBytes, ref long rawTotalNumberOfFreeBytes,
+            [MarshalAs(UnmanagedType.LPStruct), In] DokanFileInfo rawFileInfo);
 
         public delegate int GetFileInformationDelegate(
             [MarshalAs(UnmanagedType.LPWStr)] string fileName, ref BY_HANDLE_FILE_INFORMATION handleFileInfo,
@@ -69,8 +69,7 @@ namespace DokanNet
 
         public delegate int GetVolumeInformationDelegate(
             [MarshalAs(UnmanagedType.LPWStr)] StringBuilder rawVolumeNameBuffer, uint rawVolumeNameSize,
-            ref uint rawVolumeSerialNumber,
-            ref uint rawMaximumComponentLength, ref FileSystemFeatures rawFileSystemFlags,
+            ref uint rawVolumeSerialNumber, ref uint rawMaximumComponentLength, ref FileSystemFeatures rawFileSystemFlags,
             [MarshalAs(UnmanagedType.LPWStr)] StringBuilder rawFileSystemNameBuffer,
             uint rawFileSystemNameSize, [MarshalAs(UnmanagedType.LPStruct), In] DokanFileInfo rawFileInfo);
 
@@ -113,15 +112,15 @@ namespace DokanNet
 
         public delegate int SetFileTimeDelegate(
             [MarshalAs(UnmanagedType.LPWStr)] string rawFileName,
-            ref FILETIME rawCreationTime,
-            ref FILETIME rawLastAccessTime,
-            ref FILETIME rawLastWriteTime, [MarshalAs(UnmanagedType.LPStruct), In/*, Out*/] DokanFileInfo rawFileInfo);
+            ref FILETIME rawCreationTime, ref FILETIME rawLastAccessTime, ref FILETIME rawLastWriteTime,
+            [MarshalAs(UnmanagedType.LPStruct), In/*, Out*/] DokanFileInfo rawFileInfo);
 
         public delegate int UnlockFileDelegate(
             [MarshalAs(UnmanagedType.LPWStr)] string rawFileName, long rawByteOffset, long rawLength,
             [MarshalAs(UnmanagedType.LPStruct), In/*, Out*/] DokanFileInfo rawFileInfo);
 
-        public delegate int UnmountDelegate([MarshalAs(UnmanagedType.LPStruct), In] DokanFileInfo rawFileInfo);
+        public delegate int UnmountDelegate(
+            [MarshalAs(UnmanagedType.LPStruct), In] DokanFileInfo rawFileInfo);
 
         public delegate int WriteFileDelegate(
             [MarshalAs(UnmanagedType.LPWStr)] string rawFileName,
@@ -130,11 +129,8 @@ namespace DokanNet
             [MarshalAs(UnmanagedType.LPStruct), In/*, Out*/] DokanFileInfo rawFileInfo);
 
         public delegate int EnumerateNamedStreamsDelegate(
-            [MarshalAs(UnmanagedType.LPWStr)] string rawFileName,
-            IntPtr rawEnumContext,
-            [MarshalAs(UnmanagedType.LPWStr)] StringBuilder rawStreamName,
-            ref uint rawStreamNameLength,
-            ref long rawStreamSize,
+            [MarshalAs(UnmanagedType.LPWStr)] string rawFileName, IntPtr rawEnumContext,
+            [MarshalAs(UnmanagedType.LPWStr)] StringBuilder rawStreamName, ref uint rawStreamNameLength, ref long rawStreamSize,
             [MarshalAs(UnmanagedType.LPStruct), In] DokanFileInfo rawFileInfo);
 
         #endregion Delegates
@@ -162,12 +158,13 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nCreateFileProxy :  " + rawFileName);
-                DbgPrint("\tCreationDisposition " + (FileMode)rawCreationDisposition);
-                DbgPrint("\tFileShare " + (FileShare)rawShare);
-                DbgPrint("\tFileAccess " + (FileAccess)rawAccessMode);
-                DbgPrint("\tFileOptions " + (FileOptions)(rawFlagsAndAttributes & 0xffffc000));
-                DbgPrint("\tFileAttributes " + (FileAttributes)(rawFlagsAndAttributes & 0x3fff));
+                DbgPrint("\nCreateFileProxy : " + rawFileName);
+                DbgPrint("\tCreationDisposition\t" + (FileMode)rawCreationDisposition);
+                DbgPrint("\tFileAccess\t" + (FileAccess)rawAccessMode);
+                DbgPrint("\tFileShare\t" + (FileShare)rawShare);
+                DbgPrint("\tFileOptions\t" + (FileOptions)(rawFlagsAndAttributes & 0xffffc000));
+                DbgPrint("\tFileAttributes\t" + (FileAttributes)(rawFlagsAndAttributes & 0x3fff));
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.CreateFile(rawFileName, (FileAccess)rawAccessMode, (FileShare)rawShare,
                                                     (FileMode)rawCreationDisposition,
@@ -175,7 +172,7 @@ namespace DokanNet
                                                     (FileAttributes)(rawFlagsAndAttributes & 0x3fff), rawFileInfo);
                 //& 0x3ffflower 14 bits i think are file atributes and rest are file options WRITE_TROUGH etc.
 
-                DbgPrint("CreateFileProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("CreateFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -183,8 +180,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("CreateFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("CreateFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -198,11 +195,12 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nOpenDirectoryProxy :  " + rawFileName);
+                DbgPrint("\nOpenDirectoryProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.OpenDirectory(rawFileName, rawFileInfo);
 
-                DbgPrint("OpenDirectoryProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("OpenDirectoryProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -210,8 +208,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("OpenDirectoryProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("OpenDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.Error;
 #endif
@@ -225,11 +223,12 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nCreateDirectoryProxy :  " + rawFileName);
+                DbgPrint("\nCreateDirectoryProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.CreateDirectory(rawFileName, rawFileInfo);
 
-                DbgPrint("CreateDirectoryProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("CreateDirectoryProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -237,8 +236,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("CreateDirectoryProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("CreateDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.Error;
 #endif
@@ -252,11 +251,12 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nCleanupProxy :  " + rawFileName);
+                DbgPrint("\nCleanupProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.Cleanup(rawFileName, rawFileInfo);
 
-                DbgPrint("CleanupProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("CleanupProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -264,8 +264,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("CleanupProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("CleanupProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -279,11 +279,12 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nCloseFileProxy :  " + rawFileName);
+                DbgPrint("\nCloseFileProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.CloseFile(rawFileName, rawFileInfo);
 
-                DbgPrint("CloseFileProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("CloseFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -291,8 +292,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("CloseFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("CloseFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -307,16 +308,15 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nReadFileProxy :  " + rawFileName);
-                DbgPrint("\tBufferLength :  " + rawBufferLength);
-                DbgPrint("\tOffset :  " + rawOffset);
+                DbgPrint("\nReadFileProxy : " + rawFileName);
+                DbgPrint("\tBufferLength\t" + rawBufferLength);
+                DbgPrint("\tOffset\t" + rawOffset);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.ReadFile(rawFileName, rawBuffer, out rawReadLength, rawOffset,
                                                   rawFileInfo);
 
-                DbgPrint("ReadFileProxy : " + rawFileName
-                    + " Return :  " + result
-                    + " ReadLength : " + rawReadLength);
+                DbgPrint("ReadFileProxy : " + rawFileName + " Return : " + result + " ReadLength : " + rawReadLength);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -324,8 +324,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("ReadFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("ReadFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -340,17 +340,16 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nWriteFileProxy :  " + rawFileName);
-                DbgPrint("\tNumberOfBytesToWrite :  " + rawNumberOfBytesToWrite);
-                DbgPrint("\tOffset :  " + rawOffset);
+                DbgPrint("\nWriteFileProxy : " + rawFileName);
+                DbgPrint("\tNumberOfBytesToWrite\t" + rawNumberOfBytesToWrite);
+                DbgPrint("\tOffset\t" + rawOffset);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.WriteFile(rawFileName, rawBuffer,
                                                    out rawNumberOfBytesWritten, rawOffset,
                                                    rawFileInfo);
 
-                DbgPrint("WriteFileProxy : " + rawFileName
-                        + " Return :  " + result
-                        + " NumberOfBytesWritten : " + rawNumberOfBytesWritten);
+                DbgPrint("WriteFileProxy : " + rawFileName + " Return : " + result + " NumberOfBytesWritten : " + rawNumberOfBytesWritten);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -358,8 +357,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("WriteFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("WriteFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -373,11 +372,12 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nFlushFileBuffersProxy :  " + rawFileName);
+                DbgPrint("\nFlushFileBuffersProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.FlushFileBuffers(rawFileName, rawFileInfo);
 
-                DbgPrint("FlushFileBuffersProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("FlushFileBuffersProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -385,8 +385,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("FlushFileBuffersProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("FlushFileBuffersProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -402,19 +402,20 @@ namespace DokanNet
             FileInformation fi;
             try
             {
-                DbgPrint("\nGetFileInformationProxy :  " + rawFileName);
+                DbgPrint("\nGetFileInformationProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.GetFileInformation(rawFileName, out fi, rawFileInfo);
 
                 if (result == DokanResult.Success)
                 {
                     Debug.Assert(fi.FileName != null);
-                    DbgPrint("\tFileName :  " + fi.FileName);
-                    DbgPrint("\tAttributes :  " + fi.Attributes);
-                    DbgPrint("\tCreationTime :  " + fi.CreationTime);
-                    DbgPrint("\tLastAccessTime :  " + fi.LastAccessTime);
-                    DbgPrint("\tLastWriteTime :  " + fi.LastWriteTime);
-                    DbgPrint("\tLength :  " + fi.Length);
+                    DbgPrint("\tFileName\t" + fi.FileName);
+                    DbgPrint("\tAttributes\t" + fi.Attributes);
+                    DbgPrint("\tCreationTime\t" + fi.CreationTime);
+                    DbgPrint("\tLastAccessTime\t" + fi.LastAccessTime);
+                    DbgPrint("\tLastWriteTime\t" + fi.LastWriteTime);
+                    DbgPrint("\tLength\t" + fi.Length);
 
                     rawHandleFileInformation.dwFileAttributes = (uint)fi.Attributes /* + FILE_ATTRIBUTE_VIRTUAL*/;
 
@@ -422,18 +423,13 @@ namespace DokanNet
                     long atime = fi.LastAccessTime.ToFileTime();
                     long mtime = fi.LastWriteTime.ToFileTime();
                     rawHandleFileInformation.ftCreationTime.dwHighDateTime = (int)(ctime >> 32);
-                    rawHandleFileInformation.ftCreationTime.dwLowDateTime =
-                        (int)(ctime & 0xffffffff);
+                    rawHandleFileInformation.ftCreationTime.dwLowDateTime = (int)(ctime & 0xffffffff);
 
-                    rawHandleFileInformation.ftLastAccessTime.dwHighDateTime =
-                        (int)(atime >> 32);
-                    rawHandleFileInformation.ftLastAccessTime.dwLowDateTime =
-                        (int)(atime & 0xffffffff);
+                    rawHandleFileInformation.ftLastAccessTime.dwHighDateTime = (int)(atime >> 32);
+                    rawHandleFileInformation.ftLastAccessTime.dwLowDateTime = (int)(atime & 0xffffffff);
 
-                    rawHandleFileInformation.ftLastWriteTime.dwHighDateTime =
-                        (int)(mtime >> 32);
-                    rawHandleFileInformation.ftLastWriteTime.dwLowDateTime =
-                        (int)(mtime & 0xffffffff);
+                    rawHandleFileInformation.ftLastWriteTime.dwHighDateTime = (int)(mtime >> 32);
+                    rawHandleFileInformation.ftLastWriteTime.dwLowDateTime = (int)(mtime & 0xffffffff);
 
                     rawHandleFileInformation.dwVolumeSerialNumber = _serialNumber;
 
@@ -444,7 +440,7 @@ namespace DokanNet
                     rawHandleFileInformation.nFileIndexLow = (uint)fi.FileName.GetHashCode();
                 }
 
-                DbgPrint("GetFileInformationProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("GetFileInformationProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -452,8 +448,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("GetFileInformationProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("GetFileInformationProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -470,7 +466,8 @@ namespace DokanNet
             {
                 IList<FileInformation> files;
 
-                DbgPrint("\nFindFilesProxy :  " + rawFileName);
+                DbgPrint("\nFindFilesProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.FindFiles(rawFileName, out files, rawFileInfo);
 
@@ -480,12 +477,12 @@ namespace DokanNet
 #if DEBUG
                     foreach (FileInformation fi in files)
                     {
-                        DbgPrint("\n\tFileName :  " + fi.FileName);
-                        DbgPrint("\tAttributes :  " + fi.Attributes);
-                        DbgPrint("\tCreationTime :  " + fi.CreationTime);
-                        DbgPrint("\tLastAccessTime :  " + fi.LastAccessTime);
-                        DbgPrint("\tLastWriteTime :  " + fi.LastWriteTime);
-                        DbgPrint("\tLength :  " + fi.Length);
+                        DbgPrint("\n\tFileName\t" + fi.FileName);
+                        DbgPrint("\tAttributes\t" + fi.Attributes);
+                        DbgPrint("\tCreationTime\t" + fi.CreationTime);
+                        DbgPrint("\tLastAccessTime\t" + fi.LastAccessTime);
+                        DbgPrint("\tLastWriteTime\t" + fi.LastWriteTime);
+                        DbgPrint("\tLength\t" + fi.Length);
                     }
 #endif
 
@@ -499,7 +496,7 @@ namespace DokanNet
                     }
                 }
 
-                DbgPrint("FindFilesProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("FindFilesProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -507,8 +504,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("FindFilesProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("FindFilesProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.InvalidHandle;
 #endif
@@ -525,20 +522,20 @@ namespace DokanNet
             {
                 dwFileAttributes = fi.Attributes,
                 ftCreationTime =
-                                   {
-                                       dwHighDateTime = (int) (ctime >> 32),
-                                       dwLowDateTime = (int) (ctime & 0xffffffff)
-                                   },
+                {
+                    dwHighDateTime = (int) (ctime >> 32),
+                    dwLowDateTime = (int) (ctime & 0xffffffff)
+                },
                 ftLastAccessTime =
-                                   {
-                                       dwHighDateTime = (int) (atime >> 32),
-                                       dwLowDateTime = (int) (atime & 0xffffffff)
-                                   },
+                {
+                    dwHighDateTime = (int) (atime >> 32),
+                    dwLowDateTime = (int) (atime & 0xffffffff)
+                },
                 ftLastWriteTime =
-                                   {
-                                       dwHighDateTime = (int) (mtime >> 32),
-                                       dwLowDateTime = (int) (mtime & 0xffffffff)
-                                   },
+                {
+                    dwHighDateTime = (int) (mtime >> 32),
+                    dwLowDateTime = (int) (mtime & 0xffffffff)
+                },
                 nFileSizeLow = (uint)(fi.Length & 0xffffffff),
                 nFileSizeHigh = (uint)(fi.Length >> 32),
                 cFileName = fi.FileName
@@ -555,12 +552,13 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nSetEndOfFileProxy :  " + rawFileName);
-                DbgPrint("\tByteOffset :  " + rawByteOffset);
+                DbgPrint("\nSetEndOfFileProxy : " + rawFileName);
+                DbgPrint("\tByteOffset\t" + rawByteOffset);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.SetEndOfFile(rawFileName, rawByteOffset, rawFileInfo);
 
-                DbgPrint("SetEndOfFileProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("SetEndOfFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -568,8 +566,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("SetEndOfFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("SetEndOfFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -581,12 +579,13 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nSetAllocationSizeProxy :  " + rawFileName);
-                DbgPrint("\tLength :  " + rawLength);
+                DbgPrint("\nSetAllocationSizeProxy : " + rawFileName);
+                DbgPrint("\tLength\t" + rawLength);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.SetAllocationSize(rawFileName, rawLength, rawFileInfo);
 
-                DbgPrint("SetAllocationSizeProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("SetAllocationSizeProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -594,8 +593,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("SetAllocationSizeProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("SetAllocationSizeProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -609,12 +608,13 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nSetAllocationSizeProxy :  " + rawFileName);
-                DbgPrint("\tAttributes :  " + (FileAttributes)rawAttributes);
+                DbgPrint("\nSetFileAttributesProxy : " + rawFileName);
+                DbgPrint("\tAttributes\t" + (FileAttributes)rawAttributes);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.SetFileAttributes(rawFileName, (FileAttributes)rawAttributes, rawFileInfo);
 
-                DbgPrint("SetFileAttributesProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("SetFileAttributesProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -622,8 +622,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("SetFileAttributesProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("SetFileAttributesProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -633,35 +633,30 @@ namespace DokanNet
         ////
 
         public int SetFileTimeProxy(string rawFileName,
-                                   ref FILETIME rawCreationTime,
-                                   ref FILETIME rawLastAccessTime,
-                                   ref FILETIME rawLastWriteTime,
+                                    ref FILETIME rawCreationTime, ref FILETIME rawLastAccessTime, ref FILETIME rawLastWriteTime,
                                     DokanFileInfo rawFileInfo)
         {
             var ctime = (rawCreationTime.dwLowDateTime != 0 || rawCreationTime.dwHighDateTime != 0) && (rawCreationTime.dwLowDateTime != -1 || rawCreationTime.dwHighDateTime != -1)
-                            ? DateTime.FromFileTime(((long)rawCreationTime.dwHighDateTime << 32) |
-                                                    (uint)rawCreationTime.dwLowDateTime)
-                                  : (DateTime?)null;
+                ? DateTime.FromFileTime(((long)rawCreationTime.dwHighDateTime << 32) | (uint)rawCreationTime.dwLowDateTime)
+                : (DateTime?)null;
             var atime = (rawLastAccessTime.dwLowDateTime != 0 || rawLastAccessTime.dwHighDateTime != 0) && (rawLastAccessTime.dwLowDateTime != -1 || rawLastAccessTime.dwHighDateTime != -1)
-                                  ? DateTime.FromFileTime(((long)rawLastAccessTime.dwHighDateTime << 32) |
-                                                          (uint)rawLastAccessTime.dwLowDateTime)
-                                  : (DateTime?)null;
+                ? DateTime.FromFileTime(((long)rawLastAccessTime.dwHighDateTime << 32) | (uint)rawLastAccessTime.dwLowDateTime)
+                : (DateTime?)null;
             var mtime = (rawLastWriteTime.dwLowDateTime != 0 || rawLastWriteTime.dwHighDateTime != 0) && (rawLastWriteTime.dwLowDateTime != -1 || rawLastWriteTime.dwHighDateTime != -1)
-                                  ? DateTime.FromFileTime(((long)rawLastWriteTime.dwHighDateTime << 32) |
-                                                          (uint)rawLastWriteTime.dwLowDateTime)
-                                  : (DateTime?)null;
+                ? DateTime.FromFileTime(((long)rawLastWriteTime.dwHighDateTime << 32) | (uint)rawLastWriteTime.dwLowDateTime)
+                : (DateTime?)null;
 
             try
             {
-                DbgPrint("\nSetFileTimeProxy :  " + rawFileName);
-                DbgPrint("\tCreateTime :  " + ctime);
-                DbgPrint("\tAccessTime :  " + atime);
-                DbgPrint("\tWriteTime :  " + mtime);
+                DbgPrint("\nSetFileTimeProxy : " + rawFileName);
+                DbgPrint("\tCreateTime\t" + ctime);
+                DbgPrint("\tAccessTime\t" + atime);
+                DbgPrint("\tWriteTime\t" + mtime);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
-                DokanResult result = _operations.SetFileTime(rawFileName, ctime, atime,
-                                                     mtime, rawFileInfo);
+                DokanResult result = _operations.SetFileTime(rawFileName, ctime, atime, mtime, rawFileInfo);
 
-                DbgPrint("SetFileTimeProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("SetFileTimeProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -669,8 +664,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("SetFileTimeProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("SetFileTimeProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -679,15 +674,17 @@ namespace DokanNet
 
         ////
 
-        public int DeleteFileProxy(string rawFileName, DokanFileInfo rawFileInfo)
+        public int DeleteFileProxy(string rawFileName,
+                                   DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nDeleteFileProxy :  " + rawFileName);
+                DbgPrint("\nDeleteFileProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.DeleteFile(rawFileName, rawFileInfo);
 
-                DbgPrint("DeleteFileProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("DeleteFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -695,8 +692,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("DeleteFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("DeleteFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -710,11 +707,12 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nDeleteDirectoryProxy :  " + rawFileName);
+                DbgPrint("\nDeleteDirectoryProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.DeleteDirectory(rawFileName, rawFileInfo);
 
-                DbgPrint("DeleteDirectoryProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("DeleteDirectoryProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -722,8 +720,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("DeleteDirectoryProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("DeleteDirectoryProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -738,14 +736,15 @@ namespace DokanNet
         {
             try
             {
-                DbgPrint("\nMoveFileProxy :  " + rawFileName);
-                DbgPrint("\tNewFileName :  " + rawNewFileName);
-                DbgPrint("\tReplaceIfExisting :  " + rawReplaceIfExisting);
+                DbgPrint("\nMoveFileProxy : " + rawFileName);
+                DbgPrint("\tNewFileName\t" + rawNewFileName);
+                DbgPrint("\tReplaceIfExisting\t" + rawReplaceIfExisting);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.MoveFile(rawFileName, rawNewFileName, rawReplaceIfExisting,
                                                   rawFileInfo);
 
-                DbgPrint("MoveFileProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("MoveFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -753,8 +752,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("MoveFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("MoveFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -763,18 +762,20 @@ namespace DokanNet
 
         ////
 
-        public int LockFileProxy(string rawFileName, long rawByteOffset,
-                                 long rawLength, DokanFileInfo rawFileInfo)
+        public int LockFileProxy(string rawFileName,
+                                 long rawByteOffset, long rawLength,
+                                 DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nLockFileProxy :  " + rawFileName);
-                DbgPrint("\tByteOffset :  " + rawByteOffset);
-                DbgPrint("\tLength :  " + rawLength);
+                DbgPrint("\nLockFileProxy : " + rawFileName);
+                DbgPrint("\tByteOffset\t" + rawByteOffset);
+                DbgPrint("\tLength\t" + rawLength);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.LockFile(rawFileName, rawByteOffset, rawLength, rawFileInfo);
 
-                DbgPrint("LockFileProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("LockFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -782,8 +783,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("LockFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("LockFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -792,18 +793,20 @@ namespace DokanNet
 
         ////
 
-        public int UnlockFileProxy(string rawFileName, long rawByteOffset,
-                                   long rawLength, DokanFileInfo rawFileInfo)
+        public int UnlockFileProxy(string rawFileName,
+                                   long rawByteOffset, long rawLength,
+                                   DokanFileInfo rawFileInfo)
         {
             try
             {
-                DbgPrint("\nUnlockFileProxy :  " + rawFileName);
-                DbgPrint("\tByteOffset :  " + rawByteOffset);
-                DbgPrint("\tLength :  " + rawLength);
+                DbgPrint("\nUnlockFileProxy : " + rawFileName);
+                DbgPrint("\tByteOffset\t" + rawByteOffset);
+                DbgPrint("\tLength\t" + rawLength);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.UnlockFile(rawFileName, rawByteOffset, rawLength, rawFileInfo);
 
-                DbgPrint("UnlockFileProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("UnlockFileProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -811,8 +814,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("UnlockFileProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("UnlockFileProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -821,21 +824,22 @@ namespace DokanNet
 
         ////
 
-        public int GetDiskFreeSpaceProxy(ref long rawFreeBytesAvailable, ref long rawTotalNumberOfBytes,
-                                         ref long rawTotalNumberOfFreeBytes, DokanFileInfo rawFileInfo)
+        public int GetDiskFreeSpaceProxy(ref long rawFreeBytesAvailable, ref long rawTotalNumberOfBytes, ref long rawTotalNumberOfFreeBytes,
+                                         DokanFileInfo rawFileInfo)
         {
             try
             {
                 DbgPrint("\nGetDiskFreeSpaceProxy");
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.GetDiskFreeSpace(out rawFreeBytesAvailable, out rawTotalNumberOfBytes,
                                                           out rawTotalNumberOfFreeBytes,
                                                           rawFileInfo);
 
-                DbgPrint("\tFreeBytesAvailable :  " + rawFreeBytesAvailable);
-                DbgPrint("\tTotalNumberOfBytes :  " + rawTotalNumberOfBytes);
-                DbgPrint("\tTotalNumberOfFreeBytes :  " + rawTotalNumberOfFreeBytes);
-                DbgPrint("GetDiskFreeSpaceProxy Return :  " + result);
+                DbgPrint("\tFreeBytesAvailable\t" + rawFreeBytesAvailable);
+                DbgPrint("\tTotalNumberOfBytes\t" + rawTotalNumberOfBytes);
+                DbgPrint("\tTotalNumberOfFreeBytes\t" + rawTotalNumberOfFreeBytes);
+                DbgPrint("GetDiskFreeSpaceProxy Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -843,21 +847,18 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("GetDiskFreeSpaceProxy Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("GetDiskFreeSpaceProxy Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
             }
         }
 
-        public int GetVolumeInformationProxy(StringBuilder rawVolumeNameBuffer,
-                                             uint rawVolumeNameSize,
-                                             ref uint rawVolumeSerialNumber,
+        public int GetVolumeInformationProxy(StringBuilder rawVolumeNameBuffer, uint rawVolumeNameSize, ref uint rawVolumeSerialNumber,
                                              ref uint rawMaximumComponentLength, ref FileSystemFeatures rawFileSystemFlags,
-                                             StringBuilder rawFileSystemNameBuffer,
-                                             uint rawFileSystemNameSize,
-                                             DokanFileInfo fileInfo)
+                                             StringBuilder rawFileSystemNameBuffer, uint rawFileSystemNameSize,
+                                             DokanFileInfo rawFileInfo)
         {
             rawMaximumComponentLength = 256;
             rawVolumeSerialNumber = _serialNumber;
@@ -866,9 +867,9 @@ namespace DokanNet
             try
             {
                 DbgPrint("\nGetVolumeInformationProxy");
-                DokanResult result = _operations.GetVolumeInformation(out label,
-                                                                 out rawFileSystemFlags, out name,
-                                                                 fileInfo);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
+
+                DokanResult result = _operations.GetVolumeInformation(out label, out rawFileSystemFlags, out name, rawFileInfo);
 
                 if (result == DokanResult.Success)
                 {
@@ -877,13 +878,13 @@ namespace DokanNet
                     rawVolumeNameBuffer.Append(label);
                     rawFileSystemNameBuffer.Append(name);
 
-                    DbgPrint("\tVolumeNameBuffer :  " + rawVolumeNameBuffer);
-                    DbgPrint("\tFileSystemNameBuffer :  " + rawFileSystemNameBuffer);
-                    DbgPrint("\tVolumeSerialNumber :  " + rawVolumeSerialNumber);
-                    DbgPrint("\tFileSystemFlags :  " + rawFileSystemFlags);
+                    DbgPrint("\tVolumeNameBuffer\t" + rawVolumeNameBuffer);
+                    DbgPrint("\tFileSystemNameBuffer\t" + rawFileSystemNameBuffer);
+                    DbgPrint("\tVolumeSerialNumber\t" + rawVolumeSerialNumber);
+                    DbgPrint("\tFileSystemFlags\t" + rawFileSystemFlags);
                 }
 
-                DbgPrint("GetVolumeInformationProxy Return :  " + result);
+                DbgPrint("GetVolumeInformationProxy Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -891,8 +892,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("GetVolumeInformationProxy Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("GetVolumeInformationProxy Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
@@ -904,10 +905,11 @@ namespace DokanNet
             try
             {
                 DbgPrint("\nUnmountProxy");
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.Unmount(rawFileInfo);
 
-                DbgPrint("UnmountProxy Return :  " + result);
+                DbgPrint("UnmountProxy Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -915,15 +917,16 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("UnmountProxy Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("UnmountProxy Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
             }
         }
 
-        public int GetFileSecurityProxy(string rawFileName, ref SECURITY_INFORMATION rawRequestedInformation,
+        public int GetFileSecurityProxy(string rawFileName,
+                                        ref SECURITY_INFORMATION rawRequestedInformation,
                                         IntPtr rawSecurityDescriptor, uint rawSecurityDescriptorLength,
                                         ref uint rawSecurityDescriptorLengthNeeded,
                                         DokanFileInfo rawFileInfo)
@@ -954,13 +957,14 @@ namespace DokanNet
             try
             {
                 DbgPrint("\nGetFileSecurityProxy : " + rawFileName);
-                DbgPrint("\tFileSystemSecurity :  " + sect);
+                DbgPrint("\tFileSystemSecurity\t" + sect);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.GetFileSecurity(rawFileName, out sec, sect, rawFileInfo);
                 if (result == DokanResult.Success /*&& sec != null*/)
                 {
                     Debug.Assert(sec != null);
-                    DbgPrint("\tFileSystemSecurity Result :  " + sec);
+                    DbgPrint("\tFileSystemSecurity Result : " + sec);
                     var buffer = sec.GetSecurityDescriptorBinaryForm();
                     rawSecurityDescriptorLengthNeeded = (uint)buffer.Length;
                     if (buffer.Length > rawSecurityDescriptorLength)
@@ -969,7 +973,7 @@ namespace DokanNet
                     Marshal.Copy(buffer, 0, rawSecurityDescriptor, buffer.Length);
                 }
 
-                DbgPrint("GetFileSecurityProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("GetFileSecurityProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -977,19 +981,17 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("GetFileSecurityProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("GetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
             }
         }
 
-        public int SetFileSecurityProxy(
-            string rawFileName, ref SECURITY_INFORMATION rawSecurityInformation,
-            IntPtr rawSecurityDescriptor, uint rawSecurityDescriptorLength,
-            DokanFileInfo rawFileInfo)
-
+        public int SetFileSecurityProxy(string rawFileName, ref SECURITY_INFORMATION rawSecurityInformation,
+                                        IntPtr rawSecurityDescriptor, uint rawSecurityDescriptorLength,
+                                        DokanFileInfo rawFileInfo)
         {
             var sect = AccessControlSections.None;
             if (rawSecurityInformation.HasFlag(SECURITY_INFORMATION.OWNER_SECURITY_INFORMATION))
@@ -1020,12 +1022,13 @@ namespace DokanNet
                 sec.SetSecurityDescriptorBinaryForm(buffer);
 
                 DbgPrint("\nSetFileSecurityProxy : " + rawFileName);
-                DbgPrint("\tAccessControlSections :  " + sect);
-                DbgPrint("\tFileSystemSecurity :  " + sec);
+                DbgPrint("\tAccessControlSections\t" + sect);
+                DbgPrint("\tFileSystemSecurity\t" + sec);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 DokanResult result = _operations.SetFileSecurity(rawFileName, sec, sect, rawFileInfo);
 
-                DbgPrint("SetFileSecurityProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("SetFileSecurityProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -1033,25 +1036,24 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("SetFileSecurityProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("SetFileSecurityProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif
             }
         }
 
-        public int EnumerateNamedStreamsProxy(
-            string rawFileName,
-            IntPtr rawEnumContext,
-            StringBuilder rawStreamName,
-            ref uint rawStreamNameLength,
-            ref long rawStreamSize,
-            DokanFileInfo rawFileInfo)
+        public int EnumerateNamedStreamsProxy(string rawFileName,
+                                              IntPtr rawEnumContext,
+                                              StringBuilder rawStreamName, ref uint rawStreamNameLength,
+                                              ref long rawStreamSize,
+                                              DokanFileInfo rawFileInfo)
         {
             try
             {
                 DbgPrint("\tEnumerateNamedStreamsProxy : " + rawFileName);
+                DbgPrint("\tContext\t" + (rawFileInfo.Context != null ? rawFileInfo.Context.GetType().Name : "<null>"));
 
                 string name;
                 DokanResult result = _operations.EnumerateNamedStreams(rawFileName, rawEnumContext, out name, out rawStreamSize , rawFileInfo);
@@ -1061,7 +1063,7 @@ namespace DokanNet
                     rawStreamNameLength = (uint)name.Length;
                 }
 
-                DbgPrint("EnumerateNamedStreamsProxy : " + rawFileName + " Return :  " + result);
+                DbgPrint("EnumerateNamedStreamsProxy : " + rawFileName + " Return : " + result);
                 return (int)result;
             }
 #pragma warning disable 0168
@@ -1069,8 +1071,8 @@ namespace DokanNet
 #pragma warning restore 0168
             {
 #if DEBUG
-                DbgPrint("EnumerateNamedStreamsProxy : " + rawFileName + " Throw :  " + ex.Message);
-                throw ex;
+                DbgPrint("EnumerateNamedStreamsProxy : " + rawFileName + " Throw : " + ex.Message);
+                throw;
 #else
                 return (int)DokanResult.FileNotFound;
 #endif

--- a/sample/DokanNetMirror/DokanNetMirror.csproj
+++ b/sample/DokanNetMirror/DokanNetMirror.csproj
@@ -41,6 +41,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
@@ -50,6 +51,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -92,7 +94,9 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DokanNet\DokanNet.csproj">

--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -12,16 +12,11 @@ namespace DokanNetMirror
     {
         private readonly string _path;
 
-        private const FileAccess DataAccess = FileAccess.ReadData |
-                                              FileAccess.WriteData |
-                                              FileAccess.AppendData |
+        private const FileAccess DataAccess = FileAccess.ReadData | FileAccess.WriteData | FileAccess.AppendData |
                                               FileAccess.Execute |
-                                              FileAccess.GenericExecute |
-                                              FileAccess.GenericWrite |
-                                              FileAccess.GenericRead;
+                                              FileAccess.GenericExecute | FileAccess.GenericWrite | FileAccess.GenericRead;
 
-        private const FileAccess DataWriteAccess = FileAccess.WriteData |
-                                                   FileAccess.AppendData |
+        private const FileAccess DataWriteAccess = FileAccess.WriteData | FileAccess.AppendData |
                                                    FileAccess.Delete |
                                                    FileAccess.GenericWrite;
 
@@ -39,8 +34,8 @@ namespace DokanNetMirror
 
         #region Implementation of IDokanOperations
 
-        public DokanResult CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode,
-                                     FileOptions options, FileAttributes attributes, DokanFileInfo info)
+        public DokanResult CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes,
+                                      DokanFileInfo info)
         {
             var path = GetPath(fileName);
 
@@ -99,10 +94,7 @@ namespace DokanNetMirror
 
             try
             {
-                info.Context = new FileStream(path, mode,
-                                              readAccess
-                                                  ? System.IO.FileAccess.Read
-                                                  : System.IO.FileAccess.ReadWrite, share, 4096, options);
+                info.Context = new FileStream(path, mode, readAccess ? System.IO.FileAccess.Read : System.IO.FileAccess.ReadWrite, share, 4096, options);
             }
             catch (UnauthorizedAccessException) // Don't have access rights
             {
@@ -198,8 +190,7 @@ namespace DokanNetMirror
             return DokanResult.Success;
         }
 
-        public DokanResult WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset,
-                                    DokanFileInfo info)
+        public DokanResult WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info)
         {
             if (info.Context == null)
             {
@@ -258,29 +249,12 @@ namespace DokanNetMirror
                 .GetFileSystemInfos()
                 .Select(finfo => new FileInformation
                 {
-                    Attributes =
-                        finfo.
-                        Attributes,
-                    CreationTime =
-                        finfo.
-                        CreationTime,
-                    LastAccessTime =
-                        finfo.
-                        LastAccessTime,
-                    LastWriteTime =
-                        finfo.
-                        LastWriteTime,
-                    Length =
-                        (finfo is
-                         FileInfo)
-                            ? ((
-                               FileInfo
-                               )finfo
-                              ).
-                                  Length
-                            : 0,
-                    FileName =
-                        finfo.Name,
+                    Attributes = finfo.Attributes,
+                    CreationTime = finfo.CreationTime,
+                    LastAccessTime = finfo.LastAccessTime,
+                    LastWriteTime = finfo.LastWriteTime,
+                    Length = (finfo is FileInfo) ? ((FileInfo)finfo).Length : 0,
+                    FileName = finfo.Name
                 }).ToArray();
 
             return DokanResult.Success;
@@ -307,24 +281,20 @@ namespace DokanNetMirror
             }
         }
 
-        public DokanResult SetFileTime(string fileName, DateTime? creationTime, DateTime? lastAccessTime,
-                                      DateTime? lastWriteTime, DokanFileInfo info)
+        public DokanResult SetFileTime(string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, DokanFileInfo info)
         {
             try
             {
                 string path = GetPath(fileName);
                 if (creationTime.HasValue)
-                {
                     File.SetCreationTime(path, creationTime.Value);
-                }
+
                 if (lastAccessTime.HasValue)
-                {
-                    File.SetCreationTime(path, lastAccessTime.Value);
-                }
+                    File.SetLastAccessTime(path, lastAccessTime.Value);
+
                 if (lastWriteTime.HasValue)
-                {
-                    File.SetCreationTime(path, lastWriteTime.Value);
-                }
+                    File.SetLastWriteTime(path, lastWriteTime.Value);
+
                 return DokanResult.Success;
             }
             catch (UnauthorizedAccessException)
@@ -347,7 +317,7 @@ namespace DokanNetMirror
         {
             return Directory.EnumerateFileSystemEntries(GetPath(fileName)).Any()
                        ? DokanResult.DirNotEmpty
-                       : DokanResult.Success; // if dir is not empdy could not delete
+                       : DokanResult.Success; // if dir is not empty could not delete
         }
 
         public DokanResult MoveFile(string oldName, string newName, bool replace, DokanFileInfo info)
@@ -427,8 +397,7 @@ namespace DokanNetMirror
 
         public DokanResult GetDiskFreeSpace(out long free, out long total, out long used, DokanFileInfo info)
         {
-            var dinfo = DriveInfo.GetDrives()
-                .Where(di => di.RootDirectory.Name == Path.GetPathRoot(_path + "\\")).Single();
+            var dinfo = DriveInfo.GetDrives().Where(di => di.RootDirectory.Name == Path.GetPathRoot(_path + "\\")).Single();
 
             used = dinfo.AvailableFreeSpace;
             total = dinfo.TotalSize;
@@ -437,10 +406,9 @@ namespace DokanNetMirror
         }
 
         public DokanResult GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features,
-                                               out string fileSystemName, DokanFileInfo info)
+                                                out string fileSystemName, DokanFileInfo info)
         {
             volumeLabel = "DOKAN";
-
             fileSystemName = "DOKAN";
 
             features = FileSystemFeatures.CasePreservedNames | FileSystemFeatures.CaseSensitiveSearch |
@@ -450,8 +418,7 @@ namespace DokanNetMirror
             return DokanResult.Success;
         }
 
-        public DokanResult GetFileSecurity(string fileName, out FileSystemSecurity security,
-                                          AccessControlSections sections, DokanFileInfo info)
+        public DokanResult GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
         {
             try
             {
@@ -467,8 +434,7 @@ namespace DokanNetMirror
             }
         }
 
-        public DokanResult SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections,
-                                          DokanFileInfo info)
+        public DokanResult SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
         {
             try
             {

--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -1,6 +1,7 @@
 ﻿using DokanNet;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
@@ -10,7 +11,7 @@ namespace DokanNetMirror
 {
     internal class Mirror : IDokanOperations
     {
-        private readonly string _path;
+        private readonly string path;
 
         private const FileAccess DataAccess = FileAccess.ReadData | FileAccess.WriteData | FileAccess.AppendData |
                                               FileAccess.Execute |
@@ -24,12 +25,49 @@ namespace DokanNetMirror
         {
             if (!Directory.Exists(path))
                 throw new ArgumentException("path");
-            _path = path;
+            this.path = path;
         }
 
         private string GetPath(string fileName)
         {
-            return _path + fileName;
+            return path + fileName;
+        }
+
+        private string ToTrace(DokanFileInfo info)
+        {
+            var context = info.Context != null ? "<" + info.Context.GetType().Name + ">" : "<null>";
+
+            return string.Format(CultureInfo.InvariantCulture, "{{{0}, {1}, {2}, {3}, {4}, #{5}, {6}, {7}}}",
+                context, info.DeleteOnClose, info.IsDirectory, info.NoCache, info.PagingIo, info.ProcessId, info.SynchronousIo, info.WriteToEndOfFile);
+        }
+
+        private string ToTrace(DateTime? date)
+        {
+            return date.HasValue ? date.Value.ToString(CultureInfo.CurrentCulture) : "<null>";
+        }
+
+        private DokanResult Trace(string method, string fileName, DokanFileInfo info, DokanResult result, params string[] parameters)
+        {
+            var extraParameters = parameters != null && parameters.Length > 0 ? ", " + string.Join(", ", parameters) : string.Empty;
+
+#if TRACE
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}('{1}', {2}{3}) -> {4}",
+                method, fileName, ToTrace(info), extraParameters, result));
+#endif
+
+            return result;
+        }
+
+        private DokanResult Trace(string method, string fileName, DokanFileInfo info,
+                                  FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes,
+                                  DokanResult result)
+        {
+#if TRACE
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}('{1}', {2}, [{3}], [{4}], [{5}], [{6}], [{7}]) -> {8}",
+                method, fileName, ToTrace(info), access, share, mode, options, attributes, result));
+#endif
+
+            return result;
         }
 
         #region Implementation of IDokanOperations
@@ -62,30 +100,29 @@ namespace DokanNetMirror
                     if (pathExists)
                     {
                         if (readWriteAttributes || pathIsDirectory)
-                        //check if only wants to read attributes,security info or open directory
+                        // check if driver only wants to read attributes, security info, or open directory
                         {
                             info.IsDirectory = pathIsDirectory;
                             info.Context = new object();
-                            // Must set it to someting if you return DokanError.Success
+                            // must set it to someting if you return DokanError.Success
 
-                            return DokanResult.Success;
+                            return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.Success);
                         }
                     }
                     else
                     {
-                        return DokanResult.FileNotFound;
+                        return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.FileNotFound);
                     }
                     break;
 
                 case FileMode.CreateNew:
                     if (pathExists)
-                        return DokanResult.AlreadyExists;
+                        return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.AlreadyExists);
                     break;
 
                 case FileMode.Truncate:
                     if (!pathExists)
-                        return DokanResult.FileNotFound;
-
+                        return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.FileNotFound);
                     break;
 
                 default:
@@ -96,12 +133,12 @@ namespace DokanNetMirror
             {
                 info.Context = new FileStream(path, mode, readAccess ? System.IO.FileAccess.Read : System.IO.FileAccess.ReadWrite, share, 4096, options);
             }
-            catch (UnauthorizedAccessException) // Don't have access rights
+            catch (UnauthorizedAccessException) // don't have access rights
             {
-                return DokanResult.AccessDenied;
+                return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.AccessDenied);
             }
 
-            return DokanResult.Success;
+            return Trace("CreateFile", fileName, info, access, share, mode, options, attributes, DokanResult.Success);
         }
 
         public DokanResult OpenDirectory(string fileName, DokanFileInfo info)
@@ -109,38 +146,44 @@ namespace DokanNetMirror
             string path = GetPath(fileName);
             if (!Directory.Exists(path))
             {
-                return DokanResult.PathNotFound;
+                return Trace("OpenDirectory", fileName, info, DokanResult.PathNotFound);
             }
 
             try
             {
-                new DirectoryInfo(path).EnumerateFileSystemInfos().Any(); // You can't list directory
+                new DirectoryInfo(path).EnumerateFileSystemInfos().Any(); // you can't list the directory
             }
             catch (UnauthorizedAccessException)
             {
-                return DokanResult.AccessDenied;
+                return Trace("OpenDirectory", fileName, info, DokanResult.AccessDenied);
             }
-            return DokanResult.Success;
+            return Trace("OpenDirectory", fileName, info, DokanResult.Success);
         }
 
         public DokanResult CreateDirectory(string fileName, DokanFileInfo info)
         {
             if (Directory.Exists(GetPath(fileName)))
-                return DokanResult.AlreadyExists;
+                return Trace("CreateDirectory", fileName, info, DokanResult.AlreadyExists);
 
             try
             {
                 Directory.CreateDirectory(GetPath(fileName));
-                return DokanResult.Success;
+                return Trace("CreateDirectory", fileName, info, DokanResult.Success);
             }
             catch (UnauthorizedAccessException)
             {
-                return DokanResult.AccessDenied;
+                return Trace("CreateDirectory", fileName, info, DokanResult.AccessDenied);
             }
         }
 
         public DokanResult Cleanup(string fileName, DokanFileInfo info)
         {
+#if TRACE
+            if (info.Context != null)
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, "{0}('{1}', {2} - entering",
+                    "Cleanup", fileName, ToTrace(info)));
+#endif
+
             if (info.Context != null && info.Context is FileStream)
             {
                 (info.Context as FileStream).Dispose();
@@ -158,17 +201,23 @@ namespace DokanNetMirror
                     File.Delete(GetPath(fileName));
                 }
             }
-            return DokanResult.Success;
+            return Trace("Cleanup", fileName, info, DokanResult.Success);
         }
 
         public DokanResult CloseFile(string fileName, DokanFileInfo info)
         {
+#if TRACE
+            if (info.Context != null)
+                Console.WriteLine(string.Format(CultureInfo.CurrentCulture, "{0}('{1}', {2} - entering",
+                    "CloseFile", fileName, ToTrace(info)));
+#endif
+
             if (info.Context != null && info.Context is FileStream)
             {
                 (info.Context as FileStream).Dispose();
             }
             info.Context = null;
-            return DokanResult.Success; // could recreate cleanup code hear but this is not called sometimes
+            return Trace("CloseFile", fileName, info, DokanResult.Success); // could recreate cleanup code here but this is not called sometimes
         }
 
         public DokanResult ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, DokanFileInfo info)
@@ -187,7 +236,7 @@ namespace DokanNetMirror
                 stream.Position = offset;
                 bytesRead = stream.Read(buffer, 0, buffer.Length);
             }
-            return DokanResult.Success;
+            return Trace("ReadFile", fileName, info, DokanResult.Success, "out " + bytesRead.ToString(), offset.ToString(CultureInfo.InvariantCulture));
         }
 
         public DokanResult WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info)
@@ -207,7 +256,7 @@ namespace DokanNetMirror
                 stream.Write(buffer, 0, buffer.Length);
                 bytesWritten = buffer.Length;
             }
-            return DokanResult.Success;
+            return Trace("WriteFile", fileName, info, DokanResult.Success, "out " + bytesWritten.ToString(), offset.ToString(CultureInfo.InvariantCulture));
         }
 
         public DokanResult FlushFileBuffers(string fileName, DokanFileInfo info)
@@ -215,17 +264,17 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).Flush();
-                return DokanResult.Success;
+                return Trace("FlushFileBuffers", fileName, info, DokanResult.Success);
             }
             catch (IOException)
             {
-                return DokanResult.DiskFull;
+                return Trace("FlushFileBuffers", fileName, info, DokanResult.DiskFull);
             }
         }
 
         public DokanResult GetFileInformation(string fileName, out FileInformation fileInfo, DokanFileInfo info)
         {
-            // may be called with info.Context=null , but usually it isn't
+            // may be called with info.Context == null, but usually it isn't
             string path = GetPath(fileName);
             FileSystemInfo finfo = new FileInfo(path);
             if (!finfo.Exists)
@@ -240,7 +289,7 @@ namespace DokanNetMirror
                 LastWriteTime = finfo.LastWriteTime,
                 Length = (finfo is FileInfo) ? ((FileInfo)finfo).Length : 0,
             };
-            return DokanResult.Success;
+            return Trace("GetFileInformation", fileName, info, DokanResult.Success);
         }
 
         public DokanResult FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info)
@@ -257,7 +306,7 @@ namespace DokanNetMirror
                     FileName = finfo.Name
                 }).ToArray();
 
-            return DokanResult.Success;
+            return Trace("FindFiles", fileName, info, DokanResult.Success);
         }
 
         public DokanResult SetFileAttributes(string fileName, FileAttributes attributes, DokanFileInfo info)
@@ -265,19 +314,19 @@ namespace DokanNetMirror
             try
             {
                 File.SetAttributes(GetPath(fileName), attributes);
-                return DokanResult.Success;
+                return Trace("SetFileAttributes", fileName, info, DokanResult.Success, attributes.ToString());
             }
             catch (UnauthorizedAccessException)
             {
-                return DokanResult.AccessDenied;
+                return Trace("SetFileAttributes", fileName, info, DokanResult.AccessDenied, attributes.ToString());
             }
             catch (FileNotFoundException)
             {
-                return DokanResult.FileNotFound;
+                return Trace("SetFileAttributes", fileName, info, DokanResult.FileNotFound, attributes.ToString());
             }
             catch (DirectoryNotFoundException)
             {
-                return DokanResult.PathNotFound;
+                return Trace("SetFileAttributes", fileName, info, DokanResult.PathNotFound, attributes.ToString());
             }
         }
 
@@ -295,29 +344,28 @@ namespace DokanNetMirror
                 if (lastWriteTime.HasValue)
                     File.SetLastWriteTime(path, lastWriteTime.Value);
 
-                return DokanResult.Success;
+                return Trace("SetFileTime", fileName, info, DokanResult.Success, ToTrace(creationTime), ToTrace(lastAccessTime), ToTrace(lastWriteTime));
             }
             catch (UnauthorizedAccessException)
             {
-                return DokanResult.AccessDenied;
+                return Trace("SetFileTime", fileName, info, DokanResult.AccessDenied, ToTrace(creationTime), ToTrace(lastAccessTime), ToTrace(lastWriteTime));
             }
             catch (FileNotFoundException)
             {
-                return DokanResult.FileNotFound;
+                return Trace("SetFileTime", fileName, info, DokanResult.FileNotFound, ToTrace(creationTime), ToTrace(lastAccessTime), ToTrace(lastWriteTime));
             }
         }
 
         public DokanResult DeleteFile(string fileName, DokanFileInfo info)
         {
-            return File.Exists(GetPath(fileName)) ? DokanResult.Success : DokanResult.FileNotFound;
-            // we just check here if we could delete file the true deletion is in Cleanup
+            return Trace("DeleteFile", fileName, info, File.Exists(GetPath(fileName)) ? DokanResult.Success : DokanResult.FileNotFound);
+            // we just check here if we could delete the file - the true deletion is in Cleanup
         }
 
         public DokanResult DeleteDirectory(string fileName, DokanFileInfo info)
         {
-            return Directory.EnumerateFileSystemEntries(GetPath(fileName)).Any()
-                       ? DokanResult.DirNotEmpty
-                       : DokanResult.Success; // if dir is not empty could not delete
+            return Trace("DeleteDirectory", fileName, info, Directory.EnumerateFileSystemEntries(GetPath(fileName)).Any() ? DokanResult.DirNotEmpty : DokanResult.Success);
+            // if dir is not empty it can't be deleted
         }
 
         public DokanResult MoveFile(string oldName, string newName, bool replace, DokanFileInfo info)
@@ -329,7 +377,7 @@ namespace DokanNetMirror
                 info.Context = null;
 
                 File.Move(oldpath, newpath);
-                return DokanResult.Success;
+                return Trace("MoveFile", oldName, info, DokanResult.Success, newName, replace.ToString(CultureInfo.InvariantCulture));
             }
             else if (replace)
             {
@@ -338,9 +386,9 @@ namespace DokanNetMirror
                 if (!info.IsDirectory)
                     File.Delete(newpath);
                 File.Move(oldpath, newpath);
-                return DokanResult.Success;
+                return Trace("MoveFile", oldName, info, DokanResult.Success, newName, replace.ToString(CultureInfo.InvariantCulture));
             }
-            return DokanResult.FileExists;
+            return Trace("MoveFile", oldName, info, DokanResult.FileExists, newName, replace.ToString(CultureInfo.InvariantCulture));
         }
 
         public DokanResult SetEndOfFile(string fileName, long length, DokanFileInfo info)
@@ -348,11 +396,11 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).SetLength(length);
-                return DokanResult.Success;
+                return Trace("SetEndOfFile", fileName, info, DokanResult.Success, length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return DokanResult.DiskFull;
+                return Trace("SetEndOfFile", fileName, info, DokanResult.DiskFull, length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -361,11 +409,11 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).SetLength(length);
-                return DokanResult.Success;
+                return Trace("SetAllocationSize", fileName, info, DokanResult.Success, length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return DokanResult.DiskFull;
+                return Trace("SetAllocationSize", fileName, info, DokanResult.DiskFull, length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -374,11 +422,11 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).Lock(offset, length);
-                return DokanResult.Success;
+                return Trace("LockFile", fileName, info, DokanResult.Success, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return DokanResult.AccessDenied;
+                return Trace("LockFile", fileName, info, DokanResult.AccessDenied, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
@@ -387,22 +435,22 @@ namespace DokanNetMirror
             try
             {
                 ((FileStream)(info.Context)).Unlock(offset, length);
-                return DokanResult.Success;
+                return Trace("UnlockFile", fileName, info, DokanResult.Success, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
             catch (IOException)
             {
-                return DokanResult.AccessDenied;
+                return Trace("UnlockFile", fileName, info, DokanResult.AccessDenied, offset.ToString(CultureInfo.InvariantCulture), length.ToString(CultureInfo.InvariantCulture));
             }
         }
 
         public DokanResult GetDiskFreeSpace(out long free, out long total, out long used, DokanFileInfo info)
         {
-            var dinfo = DriveInfo.GetDrives().Where(di => di.RootDirectory.Name == Path.GetPathRoot(_path + "\\")).Single();
+            var dinfo = DriveInfo.GetDrives().Where(di => di.RootDirectory.Name == Path.GetPathRoot(path + "\\")).Single();
 
             used = dinfo.AvailableFreeSpace;
             total = dinfo.TotalSize;
             free = dinfo.TotalFreeSpace;
-            return DokanResult.Success;
+            return Trace("GetDiskFreeSpace", null, info, DokanResult.Success, "out " + free.ToString(), "out " + total.ToString(), "out " + used.ToString());
         }
 
         public DokanResult GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features,
@@ -415,7 +463,7 @@ namespace DokanNetMirror
                        FileSystemFeatures.PersistentAcls | FileSystemFeatures.SupportsRemoteStorage |
                        FileSystemFeatures.UnicodeOnDisk;
 
-            return DokanResult.Success;
+            return Trace("GetVolumeInformation", null, info, DokanResult.Success, "out " + volumeLabel, "out " + features.ToString(), "out " + fileSystemName);
         }
 
         public DokanResult GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
@@ -425,12 +473,12 @@ namespace DokanNetMirror
                 security = info.IsDirectory
                                ? (FileSystemSecurity)Directory.GetAccessControl(GetPath(fileName))
                                : File.GetAccessControl(GetPath(fileName));
-                return DokanResult.Success;
+                return Trace("GetFileSecurity", fileName, info, DokanResult.Success, sections.ToString());
             }
             catch (UnauthorizedAccessException)
             {
                 security = null;
-                return DokanResult.AccessDenied;
+                return Trace("GetFileSecurity", fileName, info, DokanResult.AccessDenied, sections.ToString());
             }
         }
 
@@ -446,24 +494,24 @@ namespace DokanNetMirror
                 {
                     File.SetAccessControl(GetPath(fileName), (FileSecurity)security);
                 }
-                return DokanResult.Success;
+                return Trace("SetFileSecurity", fileName, info, DokanResult.Success, sections.ToString());
             }
             catch (UnauthorizedAccessException)
             {
-                return DokanResult.AccessDenied;
+                return Trace("SetFileSecurity", fileName, info, DokanResult.AccessDenied, sections.ToString());
             }
         }
 
         public DokanResult Unmount(DokanFileInfo info)
         {
-            return DokanResult.Success;
+            return Trace("Unmount", null, info, DokanResult.Success);
         }
 
         public DokanResult EnumerateNamedStreams(string fileName, IntPtr enumContext, out string streamName, out long streamSize, DokanFileInfo info)
         {
             streamName = String.Empty;
             streamSize = 0;
-            return DokanResult.Error;
+            return Trace("EnumerateNamedStreams", fileName, info, DokanResult.Error, enumContext.ToString(), "out " + streamName, "out " + streamSize.ToString());
         }
 
         #endregion Implementation of IDokanOperations


### PR DESCRIPTION
DokanNet
  `DokanOperationsProxy` now returns `DokanResult.ExecptionInService` except for rethrowing the .NET Exception to the Dokan driver in all build targets
  Activation of tracing switched to define TRACE instead of DEBUG
  Minor fixes to glitches in tracing and minor reformatting

Sample\\Mirror
  Minor fixes to glitches in Mirror sample
  Added tracing to Mirror sample

DokanNet.Tests:
  Fixed tests for directory and subdirectory creation
  Improved handling of Exceptions thrown in tests
