### PR TITLE
Fix DokanNet.Tests [TestCategory.Manual]

### DIFF
--- a/DokanNet.Tests/DirectoryInfoTest.cs
+++ b/DokanNet.Tests/DirectoryInfoTest.cs
@@ -442,6 +442,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "SubDirectory")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void GetDirectories_OnSubDirectory_CallsApiCorrectly()
         {
@@ -528,6 +529,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "SubDirectory")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void GetFiles_OnSubDirectory_CallsApiCorrectly()
         {
@@ -614,6 +616,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "SubDirectory")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void GetFileSystemInfos_OnSubDirectory_CallsApiCorrectly()
         {
@@ -756,6 +759,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "ParentIs")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void MoveTo_WhereParentIsDirectory_CallsApiCorrectly()
         {

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -11,6 +11,7 @@ using static DokanNet.Tests.FileSettings;
 
 namespace DokanNet.Tests
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
     internal sealed class DokanOperationsFixture
     {
         private class Proxy : IDokanOperations

--- a/DokanNet.Tests/DriveInfoTest.cs
+++ b/DokanNet.Tests/DriveInfoTest.cs
@@ -46,7 +46,7 @@ namespace DokanNet.Tests
 #endif
         }
 
-        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Manual)]
+        [TestMethod, TestCategory(TestCategories.Success)]
         public void GetDriveFormat_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;
@@ -176,7 +176,7 @@ namespace DokanNet.Tests
 #endif
         }
 
-        [TestMethod, TestCategory(TestCategories.Success), TestCategory(TestCategories.Manual)]
+        [TestMethod, TestCategory(TestCategories.Success)]
         public void GetVolumeLabel_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;

--- a/DokanNet.Tests/FileInfoTest.cs
+++ b/DokanNet.Tests/FileInfoTest.cs
@@ -11,6 +11,8 @@ namespace DokanNet.Tests
     [TestClass]
     public sealed class FileInfoTest
     {
+        private const int FILE_BUFFER_SIZE = 262144;
+
         private static byte[] smallData;
 
         private static byte[] largeData;
@@ -22,7 +24,7 @@ namespace DokanNet.Tests
             for (int i = 0; i < smallData.Length; ++i)
                 smallData[i] = (byte)(i % 256);
 
-            largeData = new byte[66560];
+            largeData = new byte[3 * FILE_BUFFER_SIZE + 65536];
             for (int i = 0; i < largeData.Length; ++i)
                 largeData[i] = (byte)(i % 251);
         }
@@ -266,6 +268,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "NonEmpty")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void CopyTo_WhereSourceIsNonEmpty_CallsApiCorrectly()
         {
@@ -299,7 +302,7 @@ namespace DokanNet.Tests
 #endif
         }
 
-        [TestMethod, TestCategory(TestCategories.Manual)]
+        [TestMethod, TestCategory(TestCategories.Success)]
         public void CopyTo_WhereSourceIsLargeFile_CallsApiCorrectly()
         {
             var fixture = DokanOperationsFixture.Instance;
@@ -316,8 +319,8 @@ namespace DokanNet.Tests
             fixture.SetupGetFileInformation(destinationPath, FileAttributes.Normal);
             fixture.SetupEnumerateNamedStreams(path, string.Empty);
             fixture.SetupSetEndOfFile(destinationPath, largeData.Length);
-            fixture.SetupReadFileInChunks(path, largeData, 4096, false);
-            fixture.SetupWriteFileInChunks(destinationPath, largeData, 4096, false);
+            fixture.SetupReadFileInChunks(path, largeData, FILE_BUFFER_SIZE, false);
+            fixture.SetupWriteFileInChunks(destinationPath, largeData, FILE_BUFFER_SIZE, false);
             fixture.SetupSetFileAttributes(destinationPath, default(FileAttributes));
             fixture.SetupSetFileTime(destinationPath);
 #endif
@@ -327,7 +330,7 @@ namespace DokanNet.Tests
             sut.CopyTo(DokanOperationsFixture.DestinationFileName.AsDriveBasedPath());
 
 #if !LOGONLY
-            //fixture.VerifyAll();
+            fixture.VerifyAll();
 #endif
         }
 
@@ -494,6 +497,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "ParentIs")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void MoveTo_WhereParentIsRoot_CallsApiCorrectly()
         {
@@ -523,6 +527,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "ParentIs")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void MoveTo_WhereParentIsDirectory_CallsApiCorrectly()
         {
@@ -895,7 +900,7 @@ namespace DokanNet.Tests
             fixture.SetupAny();
 #else
             fixture.SetupCreateFile(path, ReadAccess, ReadOnlyShare, FileMode.Open);
-            fixture.SetupReadFileInChunks(path, largeData, 4096);
+            fixture.SetupReadFileInChunks(path, largeData, FILE_BUFFER_SIZE);
 #endif
 
             var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
@@ -933,7 +938,7 @@ namespace DokanNet.Tests
             fixture.SetupAny();
 #else
             fixture.SetupCreateFile(path, ReadAccess, ReadOnlyShare, FileMode.Open, context: largeData);
-            fixture.SetupReadFileInChunksUsingContext(path, largeData, 4096);
+            fixture.SetupReadFileInChunksUsingContext(path, largeData, FILE_BUFFER_SIZE);
 #endif
 
             var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
@@ -1101,7 +1106,7 @@ namespace DokanNet.Tests
             fixture.SetupAny();
 #else
             fixture.SetupCreateFile(path, WriteAccess, WriteShare, FileMode.OpenOrCreate);
-            fixture.SetupWriteFileInChunks(path, largeData, 4096);
+            fixture.SetupWriteFileInChunks(path, largeData, FILE_BUFFER_SIZE);
 #endif
 
             var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
@@ -1112,7 +1117,7 @@ namespace DokanNet.Tests
                 int totalWrittenBytes = 0;
                 do
                 {
-                    int writtenBytes = Math.Min(4096, largeData.Length - totalWrittenBytes);
+                    int writtenBytes = Math.Min(FILE_BUFFER_SIZE, largeData.Length - totalWrittenBytes);
                     stream.Write(largeData, totalWrittenBytes, writtenBytes);
                     totalWrittenBytes += writtenBytes;
                 } while (totalWrittenBytes < largeData.Length);
@@ -1137,7 +1142,7 @@ namespace DokanNet.Tests
             fixture.SetupAny();
 #else
             fixture.SetupCreateFile(path, WriteAccess, WriteShare, FileMode.OpenOrCreate, context: largeData);
-            fixture.SetupWriteFileInChunksUsingContext(path, largeData, 4096);
+            fixture.SetupWriteFileInChunksUsingContext(path, largeData, FILE_BUFFER_SIZE);
 #endif
 
             var sut = new FileInfo(DokanOperationsFixture.FileName.AsDriveBasedPath());
@@ -1148,7 +1153,7 @@ namespace DokanNet.Tests
                 int totalWrittenBytes = 0;
                 do
                 {
-                    int writtenBytes = Math.Min(4096, largeData.Length - totalWrittenBytes);
+                    int writtenBytes = Math.Min(FILE_BUFFER_SIZE, largeData.Length - totalWrittenBytes);
                     stream.Write(largeData, totalWrittenBytes, writtenBytes);
                     totalWrittenBytes += writtenBytes;
                 } while (totalWrittenBytes < largeData.Length);
@@ -1230,6 +1235,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "ParentIs")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void Replace_WhereParentIsRoot_CallsApiCorrectly()
         {
@@ -1270,6 +1276,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "ParentIs")]
         [TestMethod, TestCategory(TestCategories.Success)]
         public void Replace_WhereParentIsDirectory_CallsApiCorrectly()
         {

--- a/DokanNet.Tests/Properties/AssemblyInfo.cs
+++ b/DokanNet.Tests/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("DokanNet.Tests")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Unit tests for dokan.NET")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DokanNet.Tests")]
@@ -17,7 +17,9 @@ using System.Runtime.InteropServices;
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
+
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -31,4 +33,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("0.8.0.0")]
 [assembly: AssemblyFileVersion("0.8.0.0")]
-[assembly: CLSCompliant(true)]

--- a/DokanNet/Properties/AssemblyInfo.cs
+++ b/DokanNet/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 //
 
 [assembly: AssemblyTitle("DokanNet")]
-[assembly: AssemblyDescription(".NET wraper for dokan - user mode filesystem")]
+[assembly: AssemblyDescription(".NET wrapper for dokan - user mode filesystem")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DokanNet")]


### PR DESCRIPTION
- Unmarked tests `GetDriveFormat_CallsApiCorrectly()` and `GetVolumeLabel_CallsApiCorrectly()` because they have consistently succeeded since dokany 0.8.0 pre-release.
- Fixed test `CopyTo_WhereSourceIsLargeFile_CallsApiCorrectly()`
- Suppress several CodeAnalysis warnings for test method naming

This PR closes https://github.com/dokan-dev/dokan-dotnet/issues/24