### PR TITLE
Add support for custom library path

### DIFF
--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -27,6 +27,27 @@ namespace DokanNet
 
         #endregion Dokan Driver Errors
 
+        private static NativeMethods _methods;
+
+        internal static NativeMethods Methods
+        {
+            get
+            {
+                if (_methods == null)
+                    _methods = new NativeMethods(); // throw new DokanException(DOKAN_ERROR, "Call Initialize() before using Dokan");
+                return _methods;
+            }
+            private set
+            {
+                _methods = value;
+            }
+        }
+
+        public static void Initialize(string dokanLibrary = null)
+        {
+            Methods = new NativeMethods(dokanLibrary);
+        }
+
         public static void Mount(this IDokanOperations operations, string mountPoint, ILogger logger = null)
         {
             Mount(operations, mountPoint, DokanOptions.FixedDrive, logger);
@@ -98,8 +119,8 @@ namespace DokanNet
                 SetFileSecurity = dokanOperationProxy.SetFileSecurityProxy,
                 FindStreams = dokanOperationProxy.FindStreamsProxy
             };
-
-            int status = NativeMethods.DokanMain(ref dokanOptions, ref dokanOperations);
+            
+            int status = Methods.DokanMain(ref dokanOptions, ref dokanOperations);
 
             switch (status)
             {
@@ -122,22 +143,28 @@ namespace DokanNet
 
         public static bool Unmount(char driveLetter)
         {
-            return NativeMethods.DokanUnmount(driveLetter) == DOKAN_SUCCESS;
+            return Methods.DokanUnmount(driveLetter) == DOKAN_SUCCESS;
         }
 
         public static bool RemoveMountPoint(string mountPoint)
         {
-            return NativeMethods.DokanRemoveMountPoint(mountPoint) == DOKAN_SUCCESS;
+            return Methods.DokanRemoveMountPoint(mountPoint) == DOKAN_SUCCESS;
         }
 
         public static int Version
         {
-            get { return (int)NativeMethods.DokanVersion(); }
+            get
+            {
+                return (int)Methods.DokanVersion();
+            }
         }
 
         public static int DriverVersion
         {
-            get { return (int)NativeMethods.DokanDriverVersion(); }
+            get
+            {
+                return (int)Methods.DokanDriverVersion();
+            }
         }
     }
 }

--- a/DokanNet/DokanFileInfo.cs
+++ b/DokanNet/DokanFileInfo.cs
@@ -91,7 +91,7 @@ namespace DokanNet
         {
             try
             {
-                return new WindowsIdentity(NativeMethods.DokanOpenRequestorToken(this));
+                return new WindowsIdentity(Dokan.Methods.DokanOpenRequestorToken(this));
             }
             catch
             {
@@ -101,7 +101,7 @@ namespace DokanNet
 
         public bool TryResetTimeout(int milliseconds)
         {
-            return NativeMethods.DokanResetTimeout((uint)milliseconds, this);
+            return Dokan.Methods.DokanResetTimeout((uint)milliseconds, this);
         }
 
         private DokanFileInfo()

--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -163,7 +163,7 @@ namespace DokanNet
                 FileAttributes fileAttributes = 0;
                 int FileAttributesAndFlags = 0;
                 int CreationDisposition = 0;
-                NativeMethods.DokanMapKernelToUserCreateFileFlags(rawFileAttributes, rawCreateOptions, rawCreateDisposition, ref FileAttributesAndFlags, ref CreationDisposition);
+                Dokan.Methods.DokanMapKernelToUserCreateFileFlags(rawFileAttributes, rawCreateOptions, rawCreateDisposition, ref FileAttributesAndFlags, ref CreationDisposition);
 
                 foreach (FileOptions fileOption in Enum.GetValues(typeof(FileOptions)))
                 {

--- a/DokanNet/Native/NativeMethods.cs
+++ b/DokanNet/Native/NativeMethods.cs
@@ -3,42 +3,49 @@ using System.Runtime.InteropServices;
 
 namespace DokanNet.Native
 {
-    internal static class NativeMethods
+    internal delegate int DokanMain(ref DOKAN_OPTIONS options, ref DOKAN_OPERATIONS operations);
+    internal delegate int DokanUnmount(char driveLetter);
+    internal delegate uint DokanVersion();
+    internal delegate uint DokanDriverVersion();
+    internal delegate int DokanRemoveMountPoint([MarshalAs(UnmanagedType.LPWStr)] string mountPoint);
+    [return:MarshalAs(UnmanagedType.Bool)]
+    internal delegate bool DokanResetTimeout(uint timeout, DokanFileInfo rawFileInfo);
+    internal delegate IntPtr DokanOpenRequestorToken(DokanFileInfo rawFileInfo);
+    internal delegate void DokanMapKernelToUserCreateFileFlags(uint fileAttributes,
+        uint createOptions,
+        uint createDisposition,
+        ref int outFileAttributesAndFlags,
+        ref int outCreationDisposition);
+
+    internal class NativeMethods
     {
-        [DllImport("dokan1.dll", ExactSpelling = true)]
-        public static extern int DokanMain(ref DOKAN_OPTIONS options, ref DOKAN_OPERATIONS operations);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string library);
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        private static extern IntPtr GetProcAddress(IntPtr library, string name);
+        
+        public NativeMethods(string dll = "dokan1.dll")
+        {
+            var library = LoadLibrary(dll);
+            if (library == IntPtr.Zero) throw new DllNotFoundException($"Couldn't load {dll}");
+            foreach (var field in GetType().GetFields())
+            {
+                var addr = GetProcAddress(library, field.Name);
+                if (addr == IntPtr.Zero)
+                    throw new DllNotFoundException($"Couldn't load {field.Name} in {dll}");
+                field.SetValue(this, Marshal.GetDelegateForFunctionPointer(addr, field.FieldType));
+            }
+        }
 
-        [DllImport("dokan1.dll", ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int DokanUnmount(char driveLetter);
-
-        [DllImport("dokan1.dll", ExactSpelling = true)]
-        public static extern uint DokanVersion();
-
-        [DllImport("dokan1.dll", ExactSpelling = true)]
-        public static extern uint DokanDriverVersion();
-
-        [DllImport("dokan1.dll", ExactSpelling = true, CharSet = CharSet.Auto)]
-        public static extern int DokanRemoveMountPoint([MarshalAs(UnmanagedType.LPWStr)] string mountPoint);
-
-        [DllImport("dokan1.dll", ExactSpelling = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool DokanResetTimeout(uint timeout, DokanFileInfo rawFileInfo);
-
-        [DllImport("dokan1.dll", ExactSpelling = true)]
-        public static extern IntPtr DokanOpenRequestorToken(DokanFileInfo rawFileInfo);
-
-        [DllImport("dokan1.dll", ExactSpelling = true)]
-        public static extern void DokanMapKernelToUserCreateFileFlags(uint FileAttributes,
-                                                                        uint CreateOptions,
-                                                                        uint CreateDisposition,
-                                                                        ref int outFileAttributesAndFlags,
-                                                                        ref int outCreationDisposition);
-
-        /*
-        [DllImport("dokan1.dll", CharSet = CharSet.Unicode)]
-        public static extern bool DokanIsNameInExpression([MarshalAs(UnmanagedType.LPWStr)] string expression,
-                                                          // matching pattern
-                                                          [MarshalAs(UnmanagedType.LPWStr)] string name, // file name
-                                                          [MarshalAs(UnmanagedType.Bool)] bool ignoreCase);*/
+#pragma warning disable 649
+        public readonly DokanMain DokanMain;
+        public readonly DokanUnmount DokanUnmount;
+        public readonly DokanVersion DokanVersion;
+        public readonly DokanDriverVersion DokanDriverVersion;
+        public readonly DokanRemoveMountPoint DokanRemoveMountPoint;
+        public readonly DokanResetTimeout DokanResetTimeout;
+        public readonly DokanOpenRequestorToken DokanOpenRequestorToken;
+        public readonly DokanMapKernelToUserCreateFileFlags DokanMapKernelToUserCreateFileFlags;
+#pragma warning restore 649
     }
 }


### PR DESCRIPTION
`Dokan.Initialize(path)` can be used for loading Dokan DLL from custom path
By default, path is `"dokan1.dll"`