### PR TITLE
Don't format string already formatted.

### DIFF
--- a/DokanNet/Logging/DebugViewLogger.cs
+++ b/DokanNet/Logging/DebugViewLogger.cs
@@ -44,9 +44,9 @@
 
         private void WriteMessageToDebugView(string category, string message, params object[] args)
         {
-            if (args.Length > 0)
+            if (args?.Length > 0)
                 message = string.Format(message, args);
-            OutputDebugString(string.Format(message, args).FormatMessageForLogging(category, loggerName));
+            OutputDebugString(message.FormatMessageForLogging(category, loggerName));
         }
     }
 }


### PR DESCRIPTION
If args is null or empty, the message should not be formatted.