### PR TITLE
Improved performance for ZwCreateFileProxy

### DIFF
--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -200,24 +200,13 @@ namespace DokanNet
         {
             try
             {
-                FileOptions fileOptions = 0;
-                FileAttributes fileAttributes = 0;
                 var fileAttributesAndFlags = 0;
                 var creationDisposition = 0;
                 NativeMethods.DokanMapKernelToUserCreateFileFlags(rawFileAttributes, rawCreateOptions,
                     rawCreateDisposition, ref fileAttributesAndFlags, ref creationDisposition);
 
-                foreach (FileOptions fileOption in Enum.GetValues(typeof(FileOptions)))
-                {
-                    if (((FileOptions)(fileAttributesAndFlags & 0xffffc000) & fileOption) == fileOption)
-                        fileOptions |= fileOption;
-                }
-
-                foreach (FileAttributes fileAttribute in Enum.GetValues(typeof(FileAttributes)))
-                {
-                    if (((FileAttributes)(fileAttributesAndFlags & 0x3fff) & fileAttribute) == fileAttribute)
-                        fileAttributes |= fileAttribute;
-                }
+                var fileAttributes = (FileAttributes)(fileAttributesAndFlags & 0x00003ff7);
+                var fileOptions = (FileOptions)(fileAttributesAndFlags & 0xdc004000);
 
                 logger.Debug("CreateFileProxy : {0}", rawFileName);
                 logger.Debug("\tCreationDisposition\t{0}", (FileMode)creationDisposition);


### PR DESCRIPTION
I have test the changed implementation by run just the changed lines in a separat program.
I iterate from `0` to `0xffff ffff` to test if it was any improvement and to verify that I didn't change functionality.

With the old implementation, the loop took two hour just to go through the first `0x0521 F660` iterations.

For the new implementation, it took **7 s** to test every values from `0` to `0xffffffff`.
That's a pretty big performance improvement.