### PR TITLE
Add missing flags to FileAccess and improve documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ packages
 TestResults
 /DokanNet/documentations/doc
 *.lock.json
+*.db
+*.opendb

--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -6,14 +6,14 @@ using DokanNet.Properties;
 namespace DokanNet
 {
     /// <summary>
-    /// Helper and extension methods to Dokan.
+    /// Helper and extension methods to %Dokan.
     /// </summary>
     public static class Dokan
     {
         #region Dokan Driver Options
 
         /// <summary>
-        /// The Dokan version that DokanNet is compatible with. Currently it is version 1.0.0.
+        /// The %Dokan version that DokanNet is compatible with. Currently it is version 1.0.0.
         /// </summary>
         /// <see cref="DOKAN_OPTIONS.Version"/>
         private const ushort DOKAN_VERSION = 100;
@@ -29,45 +29,45 @@ namespace DokanNet
         */
         /** @{ */
         /// <summary>
-        /// Dokan mount succeed.
+        /// %Dokan mount succeed.
         /// </summary>
         private const int DOKAN_SUCCESS = 0;
 
         /// <summary>
-        /// Dokan mount error.
+        /// %Dokan mount error.
         /// </summary>
         private const int DOKAN_ERROR = -1;
 
         /// <summary>
-        /// Dokan mount failed - Bad drive letter.
+        /// %Dokan mount failed - Bad drive letter.
         /// </summary>
         private const int DOKAN_DRIVE_LETTER_ERROR = -2;
 
         /// <summary>
-        /// Dokan mount failed - Can't install driver.
+        /// %Dokan mount failed - Can't install driver.
         /// </summary>
         private const int DOKAN_DRIVER_INSTALL_ERROR = -3;
 
         /// <summary>
-        /// Dokan mount failed - Driver answer that something is wrong.
+        /// %Dokan mount failed - Driver answer that something is wrong.
         /// </summary>
         private const int DOKAN_START_ERROR = -4;
 
         /// <summary>
-        /// Dokan mount failed.
+        /// %Dokan mount failed.
         /// Can't assign a drive letter or mount point.
         /// Probably already used by another volume.
         /// </summary>
         private const int DOKAN_MOUNT_ERROR = -5;
 
         /// <summary>
-        /// Dokan mount failed.
+        /// %Dokan mount failed.
         /// Mount point is invalid.
         /// </summary>
         private const int DOKAN_MOUNT_POINT_ERROR = -6;
 
         /// <summary>
-        /// Dokan mount failed.
+        /// %Dokan mount failed.
         /// Requested an incompatible version.
         /// </summary>
         private const int DOKAN_VERSION_ERROR = -7;
@@ -76,7 +76,7 @@ namespace DokanNet
         #endregion Dokan Driver Errors
 
         /// <summary>
-        /// Mount a new Dokan Volume.
+        /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
         /// </summary>
         /// <param name="operations">Instance of <see cref="IDokanOperations"/> that will be called for each request made by the kernel.</param>
@@ -89,7 +89,7 @@ namespace DokanNet
         }
 
         /// <summary>
-        /// Mount a new Dokan Volume.
+        /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
         /// </summary>
         /// <param name="operations">Instance of <see cref="IDokanOperations"/> that will be called for each request made by the kernel.</param>
@@ -104,13 +104,13 @@ namespace DokanNet
         }
 
         /// <summary>
-        /// Mount a new Dokan Volume.
+        /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
         /// </summary>
         /// <param name="operations">Instance of <see cref="IDokanOperations"/> that will be called for each request made by the kernel.</param>
         /// <param name="mountPoint">Mount point. Can be <c>M:\\</c> (drive letter) or <c>C:\\mount\\dokan</c> (path in NTFS).</param>
         /// <param name="mountOptions"><see cref="DokanOptions"/> features enable for the mount.</param>
-        /// <param name="threadCount">Number of threads to be used internally by Dokan library. More thread will handle more event at the same time.</param>
+        /// <param name="threadCount">Number of threads to be used internally by %Dokan library. More thread will handle more event at the same time.</param>
         /// <param name="logger"><see cref="ILogger"/> that will log all DokanNet debug informations.</param>
         /// <exception cref="DokanException">If the mount fails.</exception>
         public static void Mount(this IDokanOperations operations, string mountPoint, DokanOptions mountOptions,
@@ -120,14 +120,14 @@ namespace DokanNet
         }
 
         /// <summary>
-        /// Mount a new Dokan Volume.
+        /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
         /// </summary>
         /// <param name="operations">Instance of <see cref="IDokanOperations"/> that will be called for each request made by the kernel.</param>
         /// <param name="mountPoint">Mount point. Can be <c>M:\\</c> (drive letter) or <c>C:\\mount\\dokan</c> (path in NTFS).</param>
         /// <param name="mountOptions"><see cref="DokanOptions"/> features enable for the mount.</param>
-        /// <param name="threadCount">Number of threads to be used internally by Dokan library. More thread will handle more event at the same time.</param>
-        /// <param name="version">Version of the dokan features requested (Version "123" is equal to Dokan version 1.2.3) (Version "123" is equal to Dokan version 1.2.3).</param>
+        /// <param name="threadCount">Number of threads to be used internally by %Dokan library. More thread will handle more event at the same time.</param>
+        /// <param name="version">Version of the dokan features requested (Version "123" is equal to %Dokan version 1.2.3).</param>
         /// <param name="logger"><see cref="ILogger"/> that will log all DokanNet debug informations.</param>
         /// <exception cref="DokanException">If the mount fails.</exception>
         public static void Mount(this IDokanOperations operations, string mountPoint, DokanOptions mountOptions,
@@ -138,14 +138,14 @@ namespace DokanNet
         }
 
         /// <summary>
-        /// Mount a new Dokan Volume.
+        /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
         /// </summary>
         /// <param name="operations">Instance of <see cref="IDokanOperations"/> that will be called for each request made by the kernel.</param>
         /// <param name="mountPoint">Mount point. Can be <c>M:\\</c> (drive letter) or <c>C:\\mount\\dokan</c> (path in NTFS).</param>
         /// <param name="mountOptions"><see cref="DokanOptions"/> features enable for the mount.</param>
-        /// <param name="threadCount">Number of threads to be used internally by Dokan library. More thread will handle more event at the same time.</param>
-        /// <param name="version">Version of the dokan features requested (Version "123" is equal to Dokan version 1.2.3).</param>
+        /// <param name="threadCount">Number of threads to be used internally by %Dokan library. More thread will handle more event at the same time.</param>
+        /// <param name="version">Version of the dokan features requested (Version "123" is equal to %Dokan version 1.2.3).</param>
         /// <param name="timeout">Max timeout in ms of each request before dokan give up.</param>
         /// <param name="logger"><see cref="ILogger"/> that will log all DokanNet debug informations.</param>
         /// <exception cref="DokanException">If the mount fails.</exception>
@@ -156,14 +156,14 @@ namespace DokanNet
         }
 
         /// <summary>
-        /// Mount a new Dokan Volume.
+        /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
         /// </summary>
         /// <param name="operations">Instance of <see cref="IDokanOperations"/> that will be called for each request made by the kernel.</param>
         /// <param name="mountPoint">Mount point. Can be <c>M:\\</c> (drive letter) or <c>C:\\mount\\dokan</c> (path in NTFS).</param>
         /// <param name="mountOptions"><see cref="DokanOptions"/> features enable for the mount.</param>
-        /// <param name="threadCount">Number of threads to be used internally by Dokan library. More thread will handle more event at the same time.</param>
-        /// <param name="version">Version of the dokan features requested (Version "123" is equal to Dokan version 1.2.3).</param>
+        /// <param name="threadCount">Number of threads to be used internally by %Dokan library. More thread will handle more event at the same time.</param>
+        /// <param name="version">Version of the dokan features requested (Version "123" is equal to %Dokan version 1.2.3).</param>
         /// <param name="timeout">Max timeout in ms of each request before dokan give up.</param>
         /// <param name="uncName">UNC name used for network volume.</param>
         /// <param name="logger"><see cref="ILogger"/> that will log all DokanNet debug informations.</param>
@@ -176,14 +176,14 @@ namespace DokanNet
 
 
         /// <summary>
-        /// Mount a new Dokan Volume.
+        /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
         /// </summary>
         /// <param name="operations">Instance of <see cref="IDokanOperations"/> that will be called for each request made by the kernel.</param>
         /// <param name="mountPoint">Mount point. Can be <c>M:\\</c> (drive letter) or <c>C:\\mount\\dokan</c> (path in NTFS).</param>
         /// <param name="mountOptions"><see cref="DokanOptions"/> features enable for the mount.</param>
-        /// <param name="threadCount">Number of threads to be used internally by Dokan library. More thread will handle more event at the same time.</param>
-        /// <param name="version">Version of the dokan features requested (Version "123" is equal to Dokan version 1.2.3).</param>
+        /// <param name="threadCount">Number of threads to be used internally by %Dokan library. More thread will handle more event at the same time.</param>
+        /// <param name="version">Version of the dokan features requested (Version "123" is equal to %Dokan version 1.2.3).</param>
         /// <param name="timeout">Max timeout in ms of each request before dokan give up.</param>
         /// <param name="uncName">UNC name used for network volume.</param>
         /// <param name="allocationUnitSize">Allocation Unit Size of the volume. This will behave on the file size.</param>
@@ -282,7 +282,7 @@ namespace DokanNet
         /// <summary>
         /// Unmount a dokan device from a mount point.
         /// </summary>
-        /// <param name="mountPoint">Mount point to unmount ("<c>Z</c>", "<c>Z:</c>", "<c>Z:\</c>", "<c>Z:\MyMountPoint</c>").</param>
+        /// <param name="mountPoint">Mount point to unmount (<c>Z</c>, <c>Z:</c>, <c>Z:\</c>, <c>Z:\MyMountPoint</c>).</param>
         /// <returns><c>true</c> if device was unmount 
         /// -or- <c>false</c> in case of failure or device not found.</returns>
         public static bool RemoveMountPoint(string mountPoint)

--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -282,7 +282,7 @@ namespace DokanNet
         /// <summary>
         /// Unmount a dokan device from a mount point.
         /// </summary>
-        /// <param name="mountPoint">Mount point to unmount (<c>Z</c>, <c>Z:</c>, <c>Z:\</c>, <c>Z:\MyMountPoint</c>).</param>
+        /// <param name="mountPoint">Mount point to unmount (<c>Z</c>, <c>Z:</c>, <c>Z:\\</c>, <c>Z:\\MyMountPoint</c>).</param>
         /// <returns><c>true</c> if device was unmount 
         /// -or- <c>false</c> in case of failure or device not found.</returns>
         public static bool RemoveMountPoint(string mountPoint)

--- a/DokanNet/DokanFileInfo.cs
+++ b/DokanNet/DokanFileInfo.cs
@@ -9,10 +9,10 @@ using static DokanNet.FormatProviders;
 namespace DokanNet
 {
     /// <summary>
-    /// Dokan file information on the current operation.
+    /// %Dokan file information on the current operation.
     /// </summary>
     /// <remarks>
-    /// This class cannot be instantiated in C#, it is created by the kernel Dokan driver.
+    /// This class cannot be instantiated in C#, it is created by the kernel %Dokan driver.
     /// This is the same structure as <c>_DOKAN_FILE_INFO</c> (dokan.h) in the C++ version of Dokan.
     /// </remarks>
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
@@ -46,7 +46,7 @@ namespace DokanNet
 
         /// <summary>
         /// Prevents a default instance of the <see cref="DokanFileInfo"/> class from being created. 
-        /// The class is created by the Dokan kernel driver.
+        /// The class is created by the %Dokan kernel driver.
         /// </summary>
         private DokanFileInfo()
         {

--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -176,28 +176,55 @@ namespace DokanNet
 
         private readonly uint serialNumber;
 
+        #region Enum masks
         /// <summary>
-        /// To be used to mask out the <see cref="FileOptions"/> flags from what is returned from <see cref="Native.NativeMethods.DokanMapKernelToUserCreateFileFlags"/>.
+        /// To be used to mask out the <see cref="FileOptions"/> flags from what is returned 
+        /// from <see cref="Native.NativeMethods.DokanMapKernelToUserCreateFileFlags"/>.
         /// </summary>
         private const int FileOptionsMask =
             (int)
-            (FileOptions.Asynchronous | FileOptions.DeleteOnClose | FileOptions.Encrypted | FileOptions.None
-             | FileOptions.RandomAccess | FileOptions.SequentialScan | FileOptions.WriteThrough);
+            ( FileOptions.Asynchronous          | FileOptions.DeleteOnClose          | FileOptions.Encrypted 
+            | FileOptions.None                  | FileOptions.RandomAccess           | FileOptions.SequentialScan 
+            | FileOptions.WriteThrough);
 
         /// <summary>
-        /// To be used to mask out the <see cref="FileAttributes"/> flags from what is returned from <see cref="Native.NativeMethods.DokanMapKernelToUserCreateFileFlags"/>.
-        /// Note that some flags where introduces in .NET Framework 4.5, and is not supported in .NET Framework 4. 
+        /// To be used to mask out the <see cref="FileAttributes"/> flags from what is returned 
+        /// from <see cref="Native.NativeMethods.DokanMapKernelToUserCreateFileFlags"/>.
+        /// Note that some flags where introduces in .NET Framework 4.5, and is not supported 
+        /// in .NET Framework 4. 
         /// </summary>
         private const int FileAttributeMask =
             (int)
-            (FileAttributes.ReadOnly | FileAttributes.Hidden | FileAttributes.System | FileAttributes.Directory
-             | FileAttributes.Archive | FileAttributes.Device | FileAttributes.Normal | FileAttributes.Temporary
-             | FileAttributes.SparseFile | FileAttributes.ReparsePoint | FileAttributes.Compressed
-             | FileAttributes.Offline | FileAttributes.NotContentIndexed | FileAttributes.Encrypted
+             ( FileAttributes.ReadOnly          | FileAttributes.Hidden              | FileAttributes.System
+             | FileAttributes.Directory         | FileAttributes.Archive             | FileAttributes.Device
+             | FileAttributes.Normal            | FileAttributes.Temporary           | FileAttributes.SparseFile
+             | FileAttributes.ReparsePoint      | FileAttributes.Compressed          | FileAttributes.Offline
+             | FileAttributes.NotContentIndexed | FileAttributes.Encrypted
 #if NET45_OR_GREATER
-             | FileAttributes.IntegrityStream | FileAttributes.NoScrubData
+             | FileAttributes.IntegrityStream   | FileAttributes.NoScrubData
 #endif
             );
+
+        /// <summary>
+        /// To be used to mask out the <see cref="FileAccess"/> flags.
+        /// </summary>
+        private const long FileAccessMask =
+            (uint)
+            ( FileAccess.ReadData               | FileAccess.WriteData               | FileAccess.AppendData 
+            | FileAccess.ReadExtendedAttributes | FileAccess.WriteExtendedAttributes | FileAccess.Execute 
+            | FileAccess.DeleteChild            | FileAccess.ReadAttributes          | FileAccess.WriteAttributes
+            | FileAccess.Delete                 | FileAccess.ReadPermissions         | FileAccess.ChangePermissions
+            | FileAccess.SetOwnership           | FileAccess.Synchronize             | FileAccess.AccessSystemSecurity
+            | FileAccess.MaximumAllowed         | FileAccess.GenericAll              | FileAccess.GenericExecute
+            | FileAccess.GenericWrite           | FileAccess.GenericRead);
+
+        /// <summary>
+        /// To be used to mask out the <see cref="FileShare"/> flags.
+        /// </summary>
+        private const int FileShareMask =
+            (int)
+            ( FileShare.ReadWrite | FileShare.Delete | FileShare.Inheritable);
+        #endregion
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DokanOperationProxy"/> class.
@@ -262,7 +289,9 @@ namespace DokanNet
                     ref creationDisposition);
 
                 var fileAttributes = (FileAttributes)(fileAttributesAndFlags & FileAttributeMask);
-                var fileOptions = (FileOptions)(fileAttributesAndFlags & FileOptionsMask);
+                var fileOptions    = (FileOptions   )(fileAttributesAndFlags & FileOptionsMask);
+                var desiredAccess  = (FileAccess    )(rawDesiredAccess       & FileAccessMask);
+                var shareAccess    = (FileShare     )(rawShareAccess         & FileShareMask);
 
                 logger.Debug("CreateFileProxy : {0}", rawFileName);
                 logger.Debug("\tCreationDisposition\t{0}", (FileMode)creationDisposition);
@@ -273,8 +302,8 @@ namespace DokanNet
                 logger.Debug("\tContext\t{0}", rawFileInfo);
                 var result = operations.CreateFile(
                     rawFileName,
-                    (FileAccess)rawDesiredAccess,
-                    (FileShare)rawShareAccess,
+                    desiredAccess,
+                    shareAccess,
                     (FileMode)creationDisposition,
                     fileOptions,
                     fileAttributes,

--- a/DokanNet/DokanResult.cs
+++ b/DokanNet/DokanResult.cs
@@ -1,7 +1,7 @@
 ﻿namespace DokanNet
 {
     /// <summary>
-    /// Defines common result status codes in <see cref="NtStatus"/> for Dokan
+    /// Defines common result status codes in <see cref="NtStatus"/> for %Dokan
     /// operations.
     /// </summary>
     public static class DokanResult

--- a/DokanNet/FileAccess.cs
+++ b/DokanNet/FileAccess.cs
@@ -7,107 +7,235 @@ namespace DokanNet
     /// These rights are used in access control entries (ACEs) and are the primary means of 
     /// specifying the requested or granted access to an object. 
     /// </summary>
+    /// <remarks>
+    /// This extends the <c><see cref="System.IO.FileAccess"/></c> enumerator in .NET that only 
+    /// contains flags for <c>Read</c> (<c>0x01</c>) and <c>Write</c> (<c>0x10</c>).
+    /// </remarks>
     /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa374896(v=vs.85).aspx">Access Mask Format (MSDN)</a>
     /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa374892(v=vs.85).aspx">ACCESS_MASK (MSDN)</a>
+    /// \see <a href="https://msdn.microsoft.com/en-us/library/4z36sx0f.aspx">FileAccess Enumeration (MSDN)</a>
     [Flags]
     public enum FileAccess : long
     {
         /// <summary>
         /// Read access right to an object.
         /// </summary>
-        ReadData = 0x00000001,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_READ_DATA,0x00000001,File & pipe}
+        /// \nativeconst{FILE_LIST_DIRECTORY,0x00000001,Directory}
+        /// \endtable
+        /// \endnative
+        ReadData = 1,
 
         /// <summary>
         /// Write access right to an object.
         /// </summary>
-        WriteData = 0x00000002,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_WRITE_DATA,0x00000002,File & pipe}
+        /// \nativeconst{FILE_ADD_FILE,0x00000002,Directory}
+        /// \endtable
+        /// \endnative
+        WriteData = 1L << 1,
 
         /// <summary>
         /// For a file object, the right to append data to the file.
         /// </summary>
-        AppendData = 0x00000004,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_APPEND_DATA,0x00000004,File}
+        /// \nativeconst{FILE_ADD_SUBDIRECTORY,0x00000004,Directory}
+        /// \nativeconst{FILE_CREATE_PIPE_INSTANCE,0x00000004,Named pipe}
+        /// \endtable
+        /// \endnative
+        AppendData = 1L << 2,
 
         /// <summary>
         /// The right to read extended file attributes.
         /// </summary>
-        ReadExtendedAttributes = 0x00000008,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_READ_EA,0x00000008,File & directory}
+        /// \endtable
+        /// \endnative
+        ReadExtendedAttributes = 1L << 3,
 
         /// <summary>
         /// The right to write extended file attributes.
         /// </summary>
-        WriteExtendedAttributes = 0x00000010,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_WRITE_EA,0x00000010,File & directory}
+        /// \endtable
+        /// \endnative
+        WriteExtendedAttributes = 1L << 4,
 
         /// <summary>
         /// For a native code file, the right to execute the file.
         /// This access right given to scripts may cause the script to be executable, depending on the script interpreter.
         /// </summary>
-        Execute = 0x00000020,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_EXECUTE,0x00000020,File}
+        /// \nativeconst{FILE_TRAVERSE,0x00000020,Directory}
+        /// \endtable
+        /// \endnative
+        Execute = 1L << 5,
+
+        /// <summary>
+        /// For a directory, the right to delete a directory and all the files it contains, including read-only files.
+        /// </summary>
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_DELETE_CHILD,0x00000040,Directory}
+        /// \endtable
+        /// \endnative
+        DeleteChild = 1L << 6,
 
         /// <summary>
         /// The right to read file attributes.
         /// </summary>
-        ReadAttributes = 0x00000080,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_READ_ATTRIBUTES,0x00000080,All}
+        /// \endtable
+        /// \endnative
+        ReadAttributes = 1L << 7,
 
         /// <summary>
         /// The right to write file attributes.
         /// </summary>
-        WriteAttributes = 0x00000100,
+        /// \native
+        /// \table
+        /// \nativeconst{FILE_WRITE_ATTRIBUTES,0x00000100,All}
+        /// \endtable
+        /// \endnative
+        WriteAttributes = 1L << 8,
 
         /// <summary>
         /// The right to delete the object.
         /// </summary>
-        Delete = 0x00010000,
+        /// \native
+        /// \table
+        /// \nativeconst{DELETE,0x00010000}
+        /// \endtable
+        /// \endnative
+        Delete = 1L << 16,
 
         /// <summary>
         /// The right to read the information in the object's security descriptor, 
         /// not including the information in the system access control list (SACL).
         /// </summary>
-        ReadPermissions = 0x00020000,
+        /// \native
+        /// \table
+        /// \nativeconst{READ_CONTROL,0x00020000}
+        /// \endtable
+        /// \endnative
+        ReadPermissions = 1L << 17,
 
         /// <summary>
         /// The right to modify the discretionary access control list (DACL) in 
         /// the object's security descriptor.
         /// </summary>
-        ChangePermissions = 0x00040000,
+        /// \native
+        /// \table
+        /// \nativeconst{WRITE_DAC,0x00040000}
+        /// \endtable
+        /// \endnative
+        ChangePermissions = 1L << 18,
 
         /// <summary>
         /// The right to change the owner in the object's security descriptor.
         /// </summary>
-        SetOwnership = 0x00080000,
+        /// \native
+        /// \table
+        /// \nativeconst{WRITE_OWNER,0x00080000}
+        /// \endtable
+        /// \endnative
+        SetOwnership = 1L << 19,
 
         /// <summary>
         /// The right to use the object for synchronization. 
         /// This enables a thread to wait until the object is in the signaled state. 
         /// Some object types do not support this access right.
         /// </summary>
-        Synchronize = 0x00100000,
+        /// \native
+        /// \table
+        /// \nativeconst{SYNCHRONIZE,0x00100000}
+        /// \endtable
+        /// \endnative
+        Synchronize = 1L << 20,
 
         /// <summary>
-        /// Access system security (ACCESS_SYSTEM_SECURITY). 
+        /// Obsolete, use <see cref="FileAccess.AccessSystemSecurity"/> instead. 
+        /// </summary>
+        [Obsolete("Use AccessSystemSecurity instead")]
+        Reserved = AccessSystemSecurity,
+
+        /// <summary>
+        /// Access system security. 
         /// It is used to indicate access to a system access control list (SACL). 
-        /// This type of access requires the calling process to have the SE_SECURITY_NAME 
+        /// This type of access requires the calling process to have the <c>SE_SECURITY_NAME</c> 
         /// (Manage auditing and security log) privilege. If this flag is set in 
         /// the access mask of an audit access ACE (successful or unsuccessful access), 
         /// the SACL access will be audited.
         /// </summary>
-        Reserved = 0x01000000,
-
-        //MaximumAllowed        = 0x02000000,
-        //GenericAll            = 0x10000000,
+        /// \native
+        /// \table
+        /// \nativeconst{ACCESS_SYSTEM_SECURITY,0x01000000}
+        /// \endtable
+        /// \endnative
+        AccessSystemSecurity = 1L << 24,
 
         /// <summary>
-        /// Generic execute access.
+        /// All the access rights that are valid for the caller.
         /// </summary>
-        GenericExecute = 0x20000000,
+        /// \native
+        /// \table
+        /// \nativeconst{MAXIMUM_ALLOWED,0x02000000}
+        /// \endtable
+        /// \endnative
+        MaximumAllowed = 1L << 25,
+
+        /// <summary>
+        /// All possible access rights.
+        /// </summary>
+        /// \native
+        /// \table
+        /// \nativeconst{GENERIC_ALL,0x10000000}
+        /// \endtable
+        /// \endnative
+        GenericAll = 1L << 28,
+
+        /// <summary>
+        /// Generic execute access. 
+        /// </summary>
+        /// \native
+        /// \table
+        /// \nativeconst{GENERIC_EXECUTE,0x20000000}
+        /// \endtable
+        /// \endnative
+        GenericExecute = 1L << 29,
 
         /// <summary>
         /// Generic write access.
         /// </summary>
-        GenericWrite = 0x40000000,
+        /// \native
+        /// \table
+        /// \nativeconst{GENERIC_WRITE,0x40000000}
+        /// \endtable
+        /// \endnative
+        GenericWrite = 1L << 30,
 
         /// <summary>
         /// Generic read access.
         /// </summary>
-        GenericRead = 0x80000000
+        /// \native
+        /// \table
+        /// \nativeconst{GENERIC_READ,0x80000000}
+        /// \endtable
+        /// \endnative
+        GenericRead = 1L << 31
     }
 }

--- a/DokanNet/FileInformation.cs
+++ b/DokanNet/FileInformation.cs
@@ -6,9 +6,11 @@ using System.Runtime.InteropServices;
 namespace DokanNet
 {
     /// <summary>
-    /// Used to provide file information to Dokan during operations
-    /// <see cref="IDokanOperations.GetFileInformation"/>, <see cref="IDokanOperations.FindFiles"/>,
-    /// <see cref="IDokanOperations.FindStreams"/> or <see cref="IDokanOperations.FindFilesWithPattern"/>.
+    /// Used to provide file information to %Dokan during operations by
+    ///  - <see cref="IDokanOperations.GetFileInformation"/>
+    ///  - <see cref="IDokanOperations.FindFiles"/>
+    ///  - <see cref="IDokanOperations.FindStreams"/> 
+    ///  - <see cref="IDokanOperations.FindFilesWithPattern"/>.
     /// </summary>
     [StructLayout(LayoutKind.Auto)]
     [DebuggerDisplay("{FileName}, {Length}, {CreationTime}, {LastWriteTime}, {LastAccessTime}, {Attributes}")]

--- a/DokanNet/IDokanOperations.cs
+++ b/DokanNet/IDokanOperations.cs
@@ -4,14 +4,14 @@ using System.IO;
 using System.Security.AccessControl;
 
 /// <summary>
-/// Base namespace for Dokan.
+/// Base namespace for %Dokan.
 /// </summary>
 namespace DokanNet
 {
     /// <summary>
-    /// Dokan API callbacks interface.
+    /// %Dokan API callbacks interface.
     /// 
-    /// A interface of callbacks that describe all Dokan API operation
+    /// A interface of callbacks that describe all %Dokan API operation
     /// that will be called when Windows access to the file system.
     /// 
     /// All this callbacks can return <see cref="NtStatus.NotImplemented"/>
@@ -315,7 +315,7 @@ namespace DokanNet
         /// <see cref="FileSystemFeatures.ReadOnlyVolume"/> is automatically added to the <paramref name="features"/> if <see cref="DokanOptions.WriteProtection"/> was
         /// specified when the volume was mounted.
         /// 
-        /// If <see cref="NtStatus.NotImplemented"/> is returned, the Dokan kernel driver use following settings by default:
+        /// If <see cref="NtStatus.NotImplemented"/> is returned, the %Dokan kernel driver use following settings by default:
         /// | Parameter                    | Default value                                                                                    |
         /// |------------------------------|--------------------------------------------------------------------------------------------------|
         /// | \a rawVolumeNameBuffer       | <c>"DOKAN"</c>                                                                                   |
@@ -373,7 +373,7 @@ namespace DokanNet
             DokanFileInfo info);
 
         /// <summary>
-        /// Is called when Dokan succeed to mount the volume.
+        /// Is called when %Dokan succeed to mount the volume.
         /// </summary>
         /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
@@ -381,7 +381,7 @@ namespace DokanNet
         NtStatus Mounted(DokanFileInfo info);
 
         /// <summary>
-        /// Is called when Dokan is unmounting the volume.
+        /// Is called when %Dokan is unmounting the volume.
         /// </summary>
         /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>

--- a/DokanNet/Logging/DebugViewLogger.cs
+++ b/DokanNet/Logging/DebugViewLogger.cs
@@ -7,7 +7,7 @@ namespace DokanNet.Logging
     /// </summary>
     /// <remarks>
     /// To see the output in visual studio 
-    /// Project + Properties, Debug tab, check "Enable unmanaged code debugging".
+    /// Project + %Properties, Debug tab, check "Enable unmanaged code debugging".
     /// </remarks> 
     public class DebugViewLogger : ILogger
     {

--- a/DokanNet/Logging/ILogger.cs
+++ b/DokanNet/Logging/ILogger.cs
@@ -4,7 +4,7 @@
 namespace DokanNet.Logging
 {
    /// <summary>
-   /// The Logger interface.
+   /// The %Logger interface.
    /// </summary>
    public interface ILogger
    {

--- a/DokanNet/NtStatus.cs
+++ b/DokanNet/NtStatus.cs
@@ -499,7 +499,7 @@
         /// <summary>
         /// Error - {Wrong Volume} The wrong volume is in the drive. Insert
         /// volume into drive.
-        /// </summary>e.
+        /// </summary>
         WrongVolume = 0xc0000012,
 
         /// <summary>

--- a/DokanNet/documentations/Doxyfile
+++ b/DokanNet/documentations/Doxyfile
@@ -238,7 +238,26 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                = 
+#        Create a generel table. A class must be defined, 
+#        or else Doxygen do its own formating of it.
+ALIASES                += table="<table class=\"customTable\">"
+ALIASES                += endtable="</table> "
+
+#        Add a row to a table started with \table.
+#        \tablerow{2} fills two cels, and let the third be empty.
+#        \tablerow{3} fills all three cels.
+ALIASES                += tablerow{2}="<tr> <td>\1</td> <td>\2</td> <td>&nbsp;</td> </tr>"
+ALIASES                += tablerow{3}="<tr> <td>\1</td> <td>\2</td> <td>\3    </td> </tr>"
+
+#        Create a headline for generel native information
+ALIASES                += native="\par %Native information"
+ALIASES                += endnative=" "
+
+#        Add a row with information about a native constant to a \table
+#        nativeconst{2} creats a row as following "SOME_CONSTANT | 0x12345678 | &nbsp;"
+#        nativeconst{3} creats a row as following "SOME_CONSTANT | 0x12345678 | Some information"
+ALIASES                += nativeconst{2}="\tablerow{\c \1,\c \2}"
+ALIASES                += nativeconst{3}="\tablerow{\c \1,\c \2,\3}"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
Add missing flags to FileAccess and improve documentation.

I have deprecated FileAccess.Reserved and replaced it with FileAccess.AccessSystemSecurity

Related to #117