### PR TITLE
Adapt to API changes for dokany 1.1.0

### DIFF
--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -388,6 +388,8 @@ namespace DokanNet.Tests
 
         private long pendingFiles;
 
+        public static bool HasPendingFiles => Instance?.pendingFiles > 0;
+
         internal static IDokanOperations Operations => proxy;
 
         internal static DokanOperationsFixture Instance { get; private set; }

--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -984,7 +984,7 @@ namespace DokanNet.Tests
         internal void ExpectOpenDirectoryWithoutCleanup(string path, FileAccess access = FileAccess.Synchronize, FileShare share = FileShare.None, FileAttributes attributes = EmptyFileAttributes)
         {
             operations
-                .Setup(d => d.CreateFile(path, access, share, FileMode.Open, ReadFileOptions, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, FileMode.Open, ReadFileOptions, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
                 .Callback((string fileName, FileAccess _access, FileShare _share, FileMode mode, FileOptions options, FileAttributes _attributes, DokanFileInfo info)
                         => Trace($"{nameof(IDokanOperations.CreateFile)}-NoCleanup[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_access}], [{_share}], {mode}, [{options}], [{_attributes}], {info.Log()})"))
@@ -1006,7 +1006,7 @@ namespace DokanNet.Tests
             return new[]
             {
                 operations
-                    .Setup(d => d.CreateFile(path, access, share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                    .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory)))
                     .Returns(DokanResult.Success)
                     .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, DokanFileInfo info)
                         => Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Increment(ref pendingFiles)}] (\"{fileName}\", [{_access}], [{_share}], {_mode}, [{_options}], [{_attributes}], {info.Log()})")),
@@ -1064,7 +1064,7 @@ namespace DokanNet.Tests
         private IVerifies SetupCreateFile(string path, FileAccess access, FileShare share, FileMode mode, FileOptions options = FileOptions.None, FileAttributes attributes = default(FileAttributes), object context = null, bool isDirectory = false)
         {
             return operations
-                .Setup(d => d.CreateFile(path, access, share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory)))
+                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory)))
                 .Returns(DokanResult.Success)
                 .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, DokanFileInfo info)
                     =>
@@ -1091,7 +1091,7 @@ namespace DokanNet.Tests
         internal void ExpectCreateFileWithoutCleanup(string path, FileAccess access, FileShare share, FileMode mode, FileOptions options = FileOptions.None, FileAttributes attributes = default(FileAttributes), object context = null, bool isDirectory = false)
         {
             operations
-                .Setup(d => d.CreateFile(path, access, share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory)))
+                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory)))
                 .Returns(DokanResult.Success)
                 .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, DokanFileInfo info)
                     =>

--- a/DokanNet.Tests/DriveInfoTests.cs
+++ b/DokanNet.Tests/DriveInfoTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static DokanNet.Tests.FileSettings;

--- a/DokanNet.Tests/DriveInfoTests.cs
+++ b/DokanNet.Tests/DriveInfoTests.cs
@@ -54,7 +54,7 @@ namespace DokanNet.Tests
 #if LOGONLY
             fixture.SetupAny();
 #else
-            fixture.ExpectOpenDirectory(DokanOperationsFixture.RootName, FileAccess.Synchronize, FileShare.None);
+            fixture.ExpectOpenDirectory(DokanOperationsFixture.RootName, FileAccess.Synchronize, FileShare.ReadWrite);
             fixture.ExpectGetVolumeInformation(DokanOperationsFixture.VOLUME_LABEL, DokanOperationsFixture.FILESYSTEM_NAME);
 #endif
 
@@ -188,7 +188,7 @@ namespace DokanNet.Tests
 #if LOGONLY
             fixture.SetupAny();
 #else
-            fixture.ExpectOpenDirectory(DokanOperationsFixture.RootName, FileAccess.Synchronize, FileShare.None);
+            fixture.ExpectOpenDirectory(DokanOperationsFixture.RootName, FileAccess.Synchronize, FileShare.ReadWrite);
             fixture.ExpectGetVolumeInformation(DokanOperationsFixture.VOLUME_LABEL, DokanOperationsFixture.FILESYSTEM_NAME);
 #endif
 

--- a/DokanNet.Tests/FileAccessUtils.cs
+++ b/DokanNet.Tests/FileAccessUtils.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+
+namespace DokanNet.Tests
+{
+    static class FileAccessUtils
+    {
+        private const FileAccess FILE_GENERIC_READ =
+            FileAccess.ReadAttributes |
+            FileAccess.ReadData |
+            FileAccess.ReadExtendedAttributes |
+            FileAccess.ReadPermissions |
+            FileAccess.Synchronize;
+
+        private const FileAccess FILE_GENERIC_WRITE =
+            FileAccess.AppendData |
+            FileAccess.WriteAttributes |
+            FileAccess.WriteData |
+            FileAccess.WriteExtendedAttributes |
+            FileAccess.ReadPermissions |
+            FileAccess.Synchronize;
+
+        private const FileAccess FILE_GENERIC_EXECUTE =
+            FileAccess.Execute |
+            FileAccess.ReadAttributes |
+            FileAccess.ReadPermissions |
+            FileAccess.Synchronize;
+
+        private static readonly FileAccess FILE_ALL_ACCESS = (FileAccess)Enum.GetValues(typeof(FileAccess)).Cast<long>().Sum();
+
+        public static FileAccess MapSpecificToGenericAccess(FileAccess desiredAccess)
+        {
+            var outDesiredAccess = desiredAccess;
+
+            var genericRead = false;
+            var genericWrite = false;
+            var genericExecute = false;
+            var genericAll = false;
+            if ((outDesiredAccess & FILE_GENERIC_READ) == FILE_GENERIC_READ)
+            {
+                outDesiredAccess |= FileAccess.GenericRead;
+                genericRead = true;
+            }
+            if ((outDesiredAccess & FILE_GENERIC_WRITE) == FILE_GENERIC_WRITE)
+            {
+                outDesiredAccess |= FileAccess.GenericWrite;
+                genericWrite = true;
+            }
+            if ((outDesiredAccess & FILE_GENERIC_EXECUTE) == FILE_GENERIC_EXECUTE)
+            {
+                outDesiredAccess |= FileAccess.GenericExecute;
+                genericExecute = true;
+            }
+            if ((outDesiredAccess & FILE_ALL_ACCESS) == FILE_ALL_ACCESS)
+            {
+                outDesiredAccess |= FileAccess.GenericAll;
+                genericAll = true;
+            }
+
+            if (genericRead)
+                outDesiredAccess &= ~FILE_GENERIC_READ;
+            if (genericWrite)
+                outDesiredAccess &= ~FILE_GENERIC_WRITE;
+            if (genericExecute)
+                outDesiredAccess &= ~FILE_GENERIC_EXECUTE;
+            if (genericAll)
+                outDesiredAccess &= ~FILE_ALL_ACCESS;
+
+            return outDesiredAccess;
+        }
+    }
+}

--- a/DokanNet.Tests/Mounter.cs
+++ b/DokanNet.Tests/Mounter.cs
@@ -27,6 +27,8 @@ namespace DokanNet.Tests
             var drive = new DriveInfo(DokanOperationsFixture.MOUNT_POINT);
             while (!drive.IsReady)
                 Thread.Sleep(50);
+            while (DokanOperationsFixture.HasPendingFiles)
+                Thread.Sleep(50);
         }
 
         [AssemblyCleanup]

--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -289,16 +289,19 @@ namespace DokanNet
             {
                 var fileAttributesAndFlags = 0;
                 var creationDisposition = 0;
+                var outDesiredAccess = 0u;
                 NativeMethods.DokanMapKernelToUserCreateFileFlags(
+                    rawDesiredAccess,
                     rawFileAttributes,
                     rawCreateOptions,
                     rawCreateDisposition,
+                    ref outDesiredAccess,
                     ref fileAttributesAndFlags,
                     ref creationDisposition);
 
                 var fileAttributes = (FileAttributes)(fileAttributesAndFlags & FileAttributeMask);
                 var fileOptions    = (FileOptions   )(fileAttributesAndFlags & FileOptionsMask);
-                var desiredAccess  = (FileAccess    )(rawDesiredAccess       & FileAccessMask);
+                var desiredAccess  = (FileAccess    )(outDesiredAccess       & FileAccessMask);
                 var shareAccess    = (FileShare     )(rawShareAccess         & FileShareMask);
 
                 logger.Debug("CreateFileProxy : {0}", rawFileName);

--- a/DokanNet/Native/NativeMethods.cs
+++ b/DokanNet/Native/NativeMethods.cs
@@ -84,17 +84,21 @@ namespace DokanNet.Native
         /// <summary>
         /// Convert <see cref="DokanOperationProxy.ZwCreateFileDelegate"/> parameters to <see cref="IDokanOperations.CreateFile"/> parameters.
         /// </summary>
+        /// <param name="desiredAccess">DesiredAccess from <see cref="DokanOperationProxy.ZwCreateFileDelegate"/>.</param>
         /// <param name="fileAttributes">FileAttributes from <see cref="DokanOperationProxy.ZwCreateFileDelegate"/>.</param>
         /// <param name="createOptions">CreateOptions from <see cref="DokanOperationProxy.ZwCreateFileDelegate"/>.</param>
         /// <param name="createDisposition">CreateDisposition from <see cref="DokanOperationProxy.ZwCreateFileDelegate"/>.</param>
+        /// <param name="outDesiredAccess">New <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx">CreateFile (MSDN)</a> dwDesiredAccess.</param>
         /// <param name="outFileAttributesAndFlags">New <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx">CreateFile (MSDN)</a> dwFlagsAndAttributes.</param>
         /// <param name="outCreationDisposition">New <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx">CreateFile (MSDN)</a> dwCreationDisposition.</param>
         /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx">CreateFile function (MSDN)</a>
         [DllImport(DOKAN_DLL, ExactSpelling = true)]
         public static extern void DokanMapKernelToUserCreateFileFlags(
+            uint desiredAccess,
             uint fileAttributes,
             uint createOptions,
             uint createDisposition,
+            ref uint outDesiredAccess,
             ref int outFileAttributesAndFlags,
             ref int outCreationDisposition);
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
  - ps: |
      Add-Type -AssemblyName System.IO.Compression.FileSystem
             (new-object System.Net.WebClient).DownloadFile(
-              'https://github.com/dokan-dev/dokany/releases/download/v1.0.3/DokanSetup_redist.exe',
+              'https://github.com/dokan-dev/dokany/releases/download/v1.1.0/DokanSetup_redist.exe',
               'C:\projects\dokan-dotnet\DokanSetup.exe'
             )
             


### PR DESCRIPTION
I updated the native call to `DokanMapKernelToUserCreateFileFlags` according to the changes in https://github.com/dokan-dev/dokany/commit/0da77870161c101d3133fd76938951c200f12868