### PR TITLE
Fix leak of the token handle in GetRequestor()

### DIFF
--- a/DokanNet/DokanFileInfo.cs
+++ b/DokanNet/DokanFileInfo.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using DokanNet.Native;
+using Microsoft.Win32.SafeHandles;
 using static DokanNet.FormatProviders;
 
 #pragma warning disable 649,169
@@ -135,13 +136,24 @@ namespace DokanNet
         /// -or- <c>null</c> if the operation was not successful.</returns>
         public WindowsIdentity GetRequestor()
         {
+            SafeFileHandle sfh = null;
             try
             {
-                return new WindowsIdentity(NativeMethods.DokanOpenRequestorToken(this));
+                using (sfh = new SafeFileHandle(NativeMethods.DokanOpenRequestorToken(this), true))
+                {
+                    return new WindowsIdentity(sfh.DangerousGetHandle());
+                }
             }
             catch
             {
                 return null;
+            }
+            finally
+            {
+                if (sfh != null)
+                {
+                    sfh.Dispose();
+                }
             }
         }
 


### PR DESCRIPTION
It turns out that the WindowsIdentity constructor doesn't take
ownership of the handle that it's passed.  As a result, the handle
returned directly from DokanOpenRequestorToken never gets closed.
Constructing a subclass of SafeHandle around it ensures that it
will be closed eventually, if it's used in a using() block.  (We
do this because there are some situations where a finally{} block
won't get executed, though we also use the finally mechanism to
attempt to dispose of it as soon as we're actually done with it.)
Because handle values of both 0 and -1 are invalid as token
handles (per the Reference Source for WindowsIdentity), we need
a subclass of SafeHandleZeroOrMinusOneIsInvalid; it turns out that
SafeFileHandle is the only concrete class that derives from it.
We could implement a SafeTokenHandle class which derives from the
same base class, but that seems like a lot of work for only one
location where it's used.  So, we construct it as a SafeFileHandle
and expect that it won't be a problem.  (If Microsoft ever
revisits the SafeFileHandle code to add in a check that the
handle it's constructed with is actually a file handle, we will
need to implement SafeTokenHandle.)