### PR TITLE
Issue #177: DokanFileInfo.Context leaks GCHandle if not set null

### DIFF
--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -355,6 +355,11 @@ namespace DokanNet
             {
                 logger.Error("CloseFileProxy : {0} Throw : {1}", rawFileName, ex.Message);
             }
+            finally
+            {
+                (rawFileInfo.Context as IDisposable)?.Dispose();
+                rawFileInfo.Context = null;
+            }
         }
 
         ////


### PR DESCRIPTION
DokanFileInfo.Context allocates a GCHandle if it's set to anything
that isn't null.  However, that GCHandle is only ever freed if it
is set to null thereafter.  This patch ensures that the GCHandle
is proprly freed before the DokanFileInfo.Context goes out of
scope.  It also checks to see if the object assigned to it can be
cast to IDisposable, and if it can it calls its .Dispose() method.
This allows for context objects to remove references to
themselves, from (e.g.) lists or dictionaries of open files used
to figure out when the file they refer to should actually be
deleted (which should only happen once all handles to the file are
closed).