### PR TITLE
Issue #177: DokanFileInfo.Context leaks GCHandle if not set null.

### DIFF
--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -355,6 +355,10 @@ namespace DokanNet
             {
                 logger.Error("CloseFileProxy : {0} Throw : {1}", rawFileName, ex.Message);
             }
+            finally
+            {
+                rawFileInfo.Context = null;
+            }
         }
 
         ////


### PR DESCRIPTION
DokanFileInfo.Context allocates a GCHandle if it's set to anything
that isn't null. However, that GCHandle is only ever freed if it
is set to null thereafter. This patch ensures that the GCHandle
is proprly freed before the DokanFileInfo goes out of scope,
without calling anything on the object the Context points to.