### PR TITLE
PR #181: expose ObjectID in FileInformation.cs

### DIFF
--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -493,8 +493,15 @@ namespace DokanNet
                     rawHandleFileInformation.nFileSizeLow = (uint)(fi.Length & 0xffffffff);
                     rawHandleFileInformation.nFileSizeHigh = (uint)(fi.Length >> 32);
                     rawHandleFileInformation.dwNumberOfLinks = 1;
-                    rawHandleFileInformation.nFileIndexHigh = 0;
-                    rawHandleFileInformation.nFileIndexLow = (uint)(fi.FileName?.GetHashCode() ?? 0);
+                    if (fi.ObjectID == default(Int64))
+                    {
+                        rawHandleFileInformation.nFileIndexHigh = 0;
+                        rawHandleFileInformation.nFileIndexLow = (uint)(fi.FileName?.GetHashCode() ?? 0);
+                    } else
+                    {
+                        rawHandleFileInformation.nFileIndexLow = (uint)fi.ObjectID & 0xffffffff;
+                        rawHandleFileInformation.nFileIndexHigh = (uint)((fi.ObjectID >> 32) & 0xffffffff);
+                    }
                 }
 
                 logger.Debug("GetFileInformationProxy : {0} Return : {1}", rawFileName, result);

--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -355,6 +355,11 @@ namespace DokanNet
             {
                 logger.Error("CloseFileProxy : {0} Throw : {1}", rawFileName, ex.Message);
             }
+            finally
+            {
+                (rawFileInfo.Context as IDisposable)?.Dispose();
+                rawFileInfo.Context = null;
+            }
         }
 
         ////

--- a/DokanNet/FileInformation.cs
+++ b/DokanNet/FileInformation.cs
@@ -48,5 +48,16 @@ namespace DokanNet
         /// Gets or sets the length of the file.
         /// </summary>
         public long Length { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ObjectID of the file. The ObjectID stays the same, even if the name
+        /// of the file changes, even if the file is moved across volumes.
+        /// </summary>
+        /// <remarks>
+        /// If you don't touch this, the default is that the high 32 bits are zeroed out, and the
+        /// low 32 bits are the HashCode of the name of the file. This does not match the
+        /// documented behavior of ObjectIDs, so working with and storing this is necessary if
+        /// your filesystem claims FileSystemFeatures.SupportsObjectIDs.</remarks>
+        public Int64 ObjectID { get; set; }
     }
 }


### PR DESCRIPTION
Currently (before this patch), the two fields of BY_HANDLE_FILE_INFORMATION called nFileIndexHigh
and nFileIndexLow are set according to the following rule: nFileIndexHigh is always 0, and nFileIndexLow is either the HashCode of the filename or 0 (if GetHashCode() fails).  This does not match the required behavior of ObjectIDs, which mandates that object IDs must stay the same for the same file, even in the face of moving or renaming it -- even across volumes.  As a result, exposing it is required for anything claiming FileSystemFeatures.SupportsObjectIDs.

There is most likely a lot more work to be done (finding a way to specify an object ID when a file is created, for example), but this is the barest bit of functionality that will allow user filesystems to start working toward ObjectID support. 