### PR TITLE
Expose strongly typed error status in DokanException

### DIFF
--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -19,62 +19,7 @@ namespace DokanNet
         private const ushort DOKAN_VERSION = 100;
 
         #endregion Dokan Driver Options
-
-        #region Dokan Driver Errors
-        /**
-        * \if PRIVATE
-        * \defgroup DokanMain DokanMain
-        * \brief DokanMain returns error codes.
-        * \endif
-        */
-        /** @{ */
-        /// <summary>
-        /// %Dokan mount succeed.
-        /// </summary>
-        private const int DOKAN_SUCCESS = 0;
-
-        /// <summary>
-        /// %Dokan mount error.
-        /// </summary>
-        private const int DOKAN_ERROR = -1;
-
-        /// <summary>
-        /// %Dokan mount failed - Bad drive letter.
-        /// </summary>
-        private const int DOKAN_DRIVE_LETTER_ERROR = -2;
-
-        /// <summary>
-        /// %Dokan mount failed - Can't install driver.
-        /// </summary>
-        private const int DOKAN_DRIVER_INSTALL_ERROR = -3;
-
-        /// <summary>
-        /// %Dokan mount failed - Driver answer that something is wrong.
-        /// </summary>
-        private const int DOKAN_START_ERROR = -4;
-
-        /// <summary>
-        /// %Dokan mount failed.
-        /// Can't assign a drive letter or mount point.
-        /// Probably already used by another volume.
-        /// </summary>
-        private const int DOKAN_MOUNT_ERROR = -5;
-
-        /// <summary>
-        /// %Dokan mount failed.
-        /// Mount point is invalid.
-        /// </summary>
-        private const int DOKAN_MOUNT_POINT_ERROR = -6;
-
-        /// <summary>
-        /// %Dokan mount failed.
-        /// Requested an incompatible version.
-        /// </summary>
-        private const int DOKAN_VERSION_ERROR = -7;
-
-        /** @} */
-        #endregion Dokan Driver Errors
-
+        
         /// <summary>
         /// Mount a new %Dokan Volume.
         /// This function block until the device is unmount.
@@ -246,25 +191,25 @@ namespace DokanNet
                 FindStreams = dokanOperationProxy.FindStreamsProxy
             };
 
-            var status = NativeMethods.DokanMain(ref dokanOptions, ref dokanOperations);
+            DokanStatus status = (DokanStatus)NativeMethods.DokanMain(ref dokanOptions, ref dokanOperations);
 
             switch (status)
             {
-                case DOKAN_SUCCESS:
+                case DokanStatus.Success:
                     break;
-                case DOKAN_ERROR:
+                case DokanStatus.Error:
                     throw new DokanException(status, Resources.ErrorDokan);
-                case DOKAN_DRIVE_LETTER_ERROR:
+                case DokanStatus.DriveLetterError:
                     throw new DokanException(status, Resources.ErrorBadDriveLetter);
-                case DOKAN_DRIVER_INSTALL_ERROR:
+                case DokanStatus.DriverInstallError:
                     throw new DokanException(status, Resources.ErrorDriverInstall);
-                case DOKAN_MOUNT_ERROR:
+                case DokanStatus.MountError:
                     throw new DokanException(status, Resources.ErrorAssignDriveLetter);
-                case DOKAN_START_ERROR:
+                case DokanStatus.StartError:
                     throw new DokanException(status, Resources.ErrorStart);
-                case DOKAN_MOUNT_POINT_ERROR:
+                case DokanStatus.MountPointError:
                     throw new DokanException(status, Resources.ErrorMountPointInvalid);
-                case DOKAN_VERSION_ERROR:
+                case DokanStatus.VersionError:
                     throw new DokanException(status, Resources.ErrorVersion);
                 default:
                     throw new DokanException(status, Resources.ErrorUnknown);

--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -1,7 +1,6 @@
 using System;
 using DokanNet.Logging;
 using DokanNet.Native;
-using DokanNet.Properties;
 
 namespace DokanNet
 {
@@ -192,28 +191,8 @@ namespace DokanNet
             };
 
             DokanStatus status = (DokanStatus)NativeMethods.DokanMain(ref dokanOptions, ref dokanOperations);
-
-            switch (status)
-            {
-                case DokanStatus.Success:
-                    break;
-                case DokanStatus.Error:
-                    throw new DokanException(status, Resources.ErrorDokan);
-                case DokanStatus.DriveLetterError:
-                    throw new DokanException(status, Resources.ErrorBadDriveLetter);
-                case DokanStatus.DriverInstallError:
-                    throw new DokanException(status, Resources.ErrorDriverInstall);
-                case DokanStatus.MountError:
-                    throw new DokanException(status, Resources.ErrorAssignDriveLetter);
-                case DokanStatus.StartError:
-                    throw new DokanException(status, Resources.ErrorStart);
-                case DokanStatus.MountPointError:
-                    throw new DokanException(status, Resources.ErrorMountPointInvalid);
-                case DokanStatus.VersionError:
-                    throw new DokanException(status, Resources.ErrorVersion);
-                default:
-                    throw new DokanException(status, Resources.ErrorUnknown);
-            }
+            if (status != DokanStatus.Success)
+                throw new DokanException(status);
         }
 
         /// <summary>

--- a/DokanNet/DokanException.cs
+++ b/DokanNet/DokanException.cs
@@ -12,14 +12,18 @@ namespace DokanNet
         /// Initializes a new instance of the <see cref="DokanException"/> class with a <see cref="Exception.HResult"/>.
         /// </summary>
         /// <param name="status">
-        /// The status for <see cref="Exception.HResult"/>.
+        /// The error status also written to <see cref="Exception.HResult"/>.
         /// </param>
         /// <param name="message">
         /// The error message.
         /// </param>
-        internal DokanException(int status, string message) : base(message)
+        internal DokanException(DokanStatus status, string message)
+            : base(message)
         {
-            HResult = status;
+            ErrorStatus = status;
+            HResult = (int)status;
         }
+
+        public DokanStatus ErrorStatus { get; private set; }
     }
 }

--- a/DokanNet/DokanException.cs
+++ b/DokanNet/DokanException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DokanNet.Properties;
 
 namespace DokanNet
 {
@@ -14,6 +15,15 @@ namespace DokanNet
         /// <param name="status">
         /// The error status also written to <see cref="Exception.HResult"/>.
         /// </param>
+        internal DokanException(DokanStatus status)
+            : this(status, GetStatusErrorMessage(status)) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DokanException"/> class with a <see cref="Exception.HResult"/>.
+        /// </summary>
+        /// <param name="status">
+        /// The error status also written to <see cref="Exception.HResult"/>.
+        /// </param>
         /// <param name="message">
         /// The error message.
         /// </param>
@@ -22,6 +32,29 @@ namespace DokanNet
         {
             ErrorStatus = status;
             HResult = (int)status;
+        }
+
+        private static string GetStatusErrorMessage(DokanStatus status)
+        {
+            switch (status)
+            {
+                case DokanStatus.Error:
+                    return Resources.ErrorDokan;
+                case DokanStatus.DriveLetterError:
+                    return Resources.ErrorBadDriveLetter;
+                case DokanStatus.DriverInstallError:
+                    return Resources.ErrorDriverInstall;
+                case DokanStatus.MountError:
+                    return Resources.ErrorAssignDriveLetter;
+                case DokanStatus.StartError:
+                    return Resources.ErrorStart;
+                case DokanStatus.MountPointError:
+                    return Resources.ErrorMountPointInvalid;
+                case DokanStatus.VersionError:
+                    return Resources.ErrorVersion;
+                default:
+                    return Resources.ErrorUnknown;
+            }
         }
 
         public DokanStatus ErrorStatus { get; private set; }

--- a/DokanNet/DokanStatus.cs
+++ b/DokanNet/DokanStatus.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DokanNet
+{
+    /// <summary>
+    /// Error codes returned by DokanMain.
+    /// </summary>
+    public enum DokanStatus : int
+    {
+        /// <summary>
+        /// %Dokan mount succeed.
+        /// </summary>
+        Success = 0,
+
+        /// <summary>
+        /// %Dokan mount error.
+        /// </summary>
+        Error = -1,
+
+        /// <summary>
+        /// %Dokan mount failed - Bad drive letter.
+        /// </summary>
+        DriveLetterError = -2,
+
+        /// <summary>
+        /// %Dokan mount failed - Can't install driver.
+        /// </summary>
+        DriverInstallError = -3,
+
+        /// <summary>
+        /// %Dokan mount failed - Driver answer that something is wrong.
+        /// </summary>
+        StartError = -4,
+
+        /// <summary>
+        /// %Dokan mount failed.
+        /// Can't assign a drive letter or mount point.
+        /// Probably already used by another volume.
+        /// </summary>
+        MountError = -5,
+
+        /// <summary>
+        /// %Dokan mount failed.
+        /// Mount point is invalid.
+        /// </summary>
+        MountPointError = -6,
+
+        /// <summary>
+        /// %Dokan mount failed.
+        /// Requested an incompatible version.
+        /// </summary>
+        VersionError = -7
+    }
+}

--- a/DokanNet/DokanStatus.cs
+++ b/DokanNet/DokanStatus.cs
@@ -10,45 +10,45 @@ namespace DokanNet
     public enum DokanStatus : int
     {
         /// <summary>
-        /// %Dokan mount succeed.
+        /// Dokan mount succeed.
         /// </summary>
         Success = 0,
 
         /// <summary>
-        /// %Dokan mount error.
+        /// Dokan mount error.
         /// </summary>
         Error = -1,
 
         /// <summary>
-        /// %Dokan mount failed - Bad drive letter.
+        /// Dokan mount failed - Bad drive letter.
         /// </summary>
         DriveLetterError = -2,
 
         /// <summary>
-        /// %Dokan mount failed - Can't install driver.
+        /// Dokan mount failed - Can't install driver.
         /// </summary>
         DriverInstallError = -3,
 
         /// <summary>
-        /// %Dokan mount failed - Driver answer that something is wrong.
+        /// Dokan mount failed - Driver answer that something is wrong.
         /// </summary>
         StartError = -4,
 
         /// <summary>
-        /// %Dokan mount failed.
+        /// Dokan mount failed.
         /// Can't assign a drive letter or mount point.
         /// Probably already used by another volume.
         /// </summary>
         MountError = -5,
 
         /// <summary>
-        /// %Dokan mount failed.
+        /// Dokan mount failed.
         /// Mount point is invalid.
         /// </summary>
         MountPointError = -6,
 
         /// <summary>
-        /// %Dokan mount failed.
+        /// Dokan mount failed.
         /// Requested an incompatible version.
         /// </summary>
         VersionError = -7


### PR DESCRIPTION
Currently, the result of DokanMain in case of error is accessible as the HResult of DokanMessage. The meaning of the different possible integer values, however, are not exposed towards the user and only privately listed in the Dokan class as constants.

I would propose to include a public enum DokanStatus in the project that clearly communicates different error states to the user. In addition to the HResult, this strongly typed status value is accessible via the ErrorStatus property in DokanException to allow straightforward error handling in user code.