### PR TITLE
Added NotADirectory enum value to DokanResult.

### DIFF
--- a/DokanNet/DokanResult.cs
+++ b/DokanNet/DokanResult.cs
@@ -105,6 +105,11 @@
         public const NtStatus Unsuccessful = NtStatus.Unsuccessful;
 
         /// <summary>
+        /// Error - A directory semantics call was made but the accessed file was not a directory.
+        /// </summary>
+        public const NtStatus NotADirectory = NtStatus.NotADirectory;
+
+        /// <summary>
         /// Error - The parameter is incorrect.
         /// </summary>
         public const NtStatus InvalidParameter = NtStatus.InvalidParameter;

--- a/DokanNet/IDokanOperations.cs
+++ b/DokanNet/IDokanOperations.cs
@@ -32,7 +32,7 @@ namespace DokanNet
         /// In this case, CreateFile should return <see cref="NtStatus.Success"/> when that directory
         /// can be opened and <see cref="DokanFileInfo.IsDirectory"/> has to be set to <c>true</c>.
         /// On the other hand, if <see cref="DokanFileInfo.IsDirectory"/> is set to <c>true</c>
-        /// but the path target a file, you need to return <see cref="NtStatus.NotADirectory"/>
+        /// but the path target a file, you need to return <see cref="DokanResult.NotADirectory"/>
         /// 
         /// <see cref="DokanFileInfo.Context"/> can be used to store data (like <c><see cref="FileStream"/></c>)
         /// that can be retrieved in all other request related to the context.

--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -71,7 +71,7 @@ namespace DokanNetMirror
         public NtStatus CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode,
             FileOptions options, FileAttributes attributes, DokanFileInfo info)
         {
-            var result = NtStatus.Success;
+            var result = DokanResult.Success;
             var filePath = GetPath(fileName);
 
             if (info.IsDirectory)
@@ -389,7 +389,7 @@ namespace DokanNetMirror
                     var lat = lastAccessTime?.ToFileTime() ?? 0;
                     var lwt = lastWriteTime?.ToFileTime() ?? 0;
                     if (NativeMethods.SetFileTime(stream.SafeFileHandle, ref ct, ref lat, ref lwt))
-                        return NtStatus.Success;
+                        return DokanResult.Success;
                     throw Marshal.GetExceptionForHR(Marshal.GetLastWin32Error());
                 }
 
@@ -537,7 +537,7 @@ namespace DokanNetMirror
             }
 #else
 // .NET Core 1.0 do not have support for FileStream.Lock
-            return NtStatus.NotImplemented;
+            return DokanResult.NotImplemented;
 #endif
         }
 
@@ -557,7 +557,7 @@ namespace DokanNetMirror
             }
 #else
 // .NET Core 1.0 do not have support for FileStream.Unlock
-            return NtStatus.NotImplemented;
+            return DokanResult.NotImplemented;
 #endif
         }
 
@@ -606,7 +606,7 @@ namespace DokanNetMirror
 #else
 // .NET Core 1.0 do not have support for Directory.GetAccessControl
             security = null;
-            return NtStatus.NotImplemented;
+            return DokanResult.NotImplemented;
 #endif
         }
 
@@ -632,7 +632,7 @@ namespace DokanNetMirror
             }
 #else
 // .NET Core 1.0 do not have support for Directory.SetAccessControl
-            return NtStatus.NotImplemented;
+            return DokanResult.NotImplemented;
 #endif
         }
 

--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -87,7 +87,7 @@ namespace DokanNetMirror
                                 {
                                     if (!File.GetAttributes(filePath).HasFlag(FileAttributes.Directory))
                                         return Trace(nameof(CreateFile), fileName, info, access, share, mode, options,
-                                            attributes, NtStatus.NotADirectory);
+                                            attributes, DokanResult.NotADirectory);
                                 }
                                 catch (Exception)
                                 {


### PR DESCRIPTION
NotADirectory was part of NtStatus but not of DokanResult. As it is a valid return value for CreateFile in some cases, it should be included in DokanResult so that consistent uses of enums can be achieved in CreateFile.

I also replaced all usages of NtStatus in the DokanNetMirror implementation with DokanResult for consistency.