### PR TITLE
CreateFile should not check if a path is a file or a directory if the path do not exist

### DIFF
--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -138,7 +138,7 @@ namespace DokanNetMirror
                 try
                 {
                     pathExists = (Directory.Exists(filePath) || File.Exists(filePath));
-                    pathIsDirectory = File.GetAttributes(filePath).HasFlag(FileAttributes.Directory);
+                    pathIsDirectory = pathExists ? File.GetAttributes(filePath).HasFlag(FileAttributes.Directory) : false;
                 }
                 catch (IOException)
                 {


### PR DESCRIPTION
fix: while invoking DIR from command prompt Mirror.CreateFile() was throwing an exception