### PR TITLE
Add methods to support Dokany 1.3.0.1000's new kernel notifications

### DIFF
--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -236,8 +236,11 @@ namespace DokanNet
         {
             StringBuilder FilePathBuilder = new StringBuilder();
             FilePathBuilder.Append(dfi.NativeDokanOptions.MountPoint);
-            // Remove the trailing backslash from the MountPoint, because FilePath includes a leading backslash
-            FilePathBuilder.Remove(FilePathBuilder.Length - 1, 1);
+            if (FilePathBuilder[FilePathBuilder.Length - 1] == '\\')
+            {
+                // Remove the trailing backslash from the MountPoint, because FilePath includes a leading backslash
+                FilePathBuilder.Remove(FilePathBuilder.Length - 1, 1);
+            }
             FilePathBuilder.Append(FilePath);
             return FilePathBuilder.ToString();
         }

--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using DokanNet.Logging;
 using DokanNet.Native;
 
@@ -15,7 +16,7 @@ namespace DokanNet
         /// The %Dokan version that DokanNet is compatible with. Currently it is version 1.0.0.
         /// </summary>
         /// <see cref="DOKAN_OPTIONS.Version"/>
-        private const ushort DOKAN_VERSION = 120;
+        private const ushort DOKAN_VERSION = 130;
 
         #endregion Dokan Driver Options
         
@@ -192,7 +193,9 @@ namespace DokanNet
 
             DokanStatus status = (DokanStatus)NativeMethods.DokanMain(ref dokanOptions, ref dokanOperations);
             if (status != DokanStatus.Success)
+            {
                 throw new DokanException(status);
+            }
         }
 
         /// <summary>
@@ -228,5 +231,78 @@ namespace DokanNet
         /// </summary>
         /// <returns>Return native dokan driver version supported.</returns>
         public static int DriverVersion => (int) NativeMethods.DokanDriverVersion();
+
+        private static string BuildFilePath(string FilePath, DokanFileInfo dfi)
+        {
+            StringBuilder FilePathBuilder = new StringBuilder();
+            FilePathBuilder.Append(dfi.NativeDokanOptions.MountPoint);
+            FilePathBuilder.Append(FilePath);
+            return FilePathBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Notify Dokan that a file or directory has been created.
+        /// </summary>
+        /// <param name="FilePath">Path within the filesystem to the file or directory.</param>
+        /// <param name="isDirectory">Indicates if the path is a directory.</param>
+        /// <param name="dfi">The DokanFileInfo that refers to this file.</param>
+        /// <returns>true if the notification succeeded.</returns>
+        public static bool DokanNotifyCreate(string FilePath, bool isDirectory, DokanFileInfo dfi)
+        {
+            return NativeMethods.DokanNotifyCreate(BuildFilePath(FilePath,dfi), isDirectory);
+        }
+
+        /// <summary>
+        /// Notify Dokan that a file or directory has been deleted.
+        /// </summary>
+        /// <param name="FilePath">Path within the filesystem to the file or directory.</param>
+        /// <param name="isDirectory">Indicates if the path is a directory.</param>
+        /// <param name="dfi">The DokanFileInfo that refers to this file.</param>
+        /// <returns>true if notification succeeded.</returns>
+        public static bool DokanNotifyDelete(string FilePath, bool isDirectory, DokanFileInfo dfi)
+        {
+            return NativeMethods.DokanNotifyDelete(BuildFilePath(FilePath,dfi), isDirectory);
+        }
+
+        /// <summary>
+        /// Notify Dokan that file or directory attributes have changed.
+        /// </summary>
+        /// <param name="FilePath">Path within the filesystem to the file or directory.</param>
+        /// <param name="dfi">The DokanFileInfo that refers to this file.</param>
+        /// <returns>true if notification succeeded.</returns>
+        public static bool DokanNotifyUpdate(string FilePath, DokanFileInfo dfi)
+        {
+            return NativeMethods.DokanNotifyUpdate(BuildFilePath(FilePath,dfi));
+        }
+
+        /// <summary>
+        /// Notify Dokan that file or directory extended attributes have changed.
+        /// </summary>
+        /// <param name="FilePath">Path within the filesystem to the file or directory.</param>
+        /// <param name="dfi">The DokanFileInfo that refers to this file.</param>
+        /// <returns>true if notification succeeded.</returns>
+        public static bool DokanNotifyXAttrUpdate(string FilePath, DokanFileInfo dfi)
+        {
+            return NativeMethods.DokanNotifyXAttrUpdate(BuildFilePath(FilePath, dfi));
+        }
+
+        /// <summary>
+        /// Notify Dokan that a file or directory has been renamed.
+        /// </summary>
+        /// <remarks>This method supports in-place rename for file/directory within the same parent.</remarks>
+        /// <param name="OldPath">Old path within the filesystem to the file or directory.</param>
+        /// <param name="NewPath">New path within the filesystem to the file or directory.</param>
+        /// <param name="isDirectory">Indicates if the path is a directory.</param>
+        /// <param name="isInSameDirectory">Indicates if OldPath and NewPath have the same parent.</param>
+        /// <param name="dfi">The DokanFileInfo that refers to this file.</param>
+        /// <returns>true if notification succeeded.</returns>
+        public static bool DokanNotifyRename(string OldPath, string NewPath, bool isDirectory, bool isInSameDirectory,
+            DokanFileInfo dfi)
+        {
+            return NativeMethods.DokanNotifyRename(BuildFilePath(OldPath, dfi),
+                BuildFilePath(NewPath, dfi),
+                isDirectory,
+                isInSameDirectory);
+        }
     }
 }

--- a/DokanNet/Dokan.cs
+++ b/DokanNet/Dokan.cs
@@ -236,6 +236,8 @@ namespace DokanNet
         {
             StringBuilder FilePathBuilder = new StringBuilder();
             FilePathBuilder.Append(dfi.NativeDokanOptions.MountPoint);
+            // Remove the trailing backslash from the MountPoint, because FilePath includes a leading backslash
+            FilePathBuilder.Remove(FilePathBuilder.Length - 1, 1);
             FilePathBuilder.Append(FilePath);
             return FilePathBuilder.ToString();
         }

--- a/DokanNet/DokanFileInfo.cs
+++ b/DokanNet/DokanFileInfo.cs
@@ -172,6 +172,11 @@ namespace DokanNet
                 DokanFormat(
                     $"{{{Context}, {DeleteOnClose}, {IsDirectory}, {NoCache}, {PagingIo}, #{ProcessId}, {SynchronousIo}, {WriteToEndOfFile}}}");
         }
+
+        internal DOKAN_OPTIONS NativeDokanOptions
+        {
+            get => (DOKAN_OPTIONS)GCHandle.FromIntPtr(_dokanOptions).Target;
+        }
     }
 }
 

--- a/DokanNet/Native/NativeMethods.cs
+++ b/DokanNet/Native/NativeMethods.cs
@@ -108,5 +108,57 @@ namespace DokanNet.Native
                                                           // matching pattern
                                                           [MarshalAs(UnmanagedType.LPWStr)] string name, // file name
                                                           [MarshalAs(UnmanagedType.Bool)] bool ignoreCase);*/
+        
+        /// <summary>
+        /// Notify Dokan that a file or directory has been created.
+        /// </summary>
+        /// <param name="FilePath">Full path to the file or directory, including mount point.</param>
+        /// <param name="isDirectory">Indicates if the path is a directory.</param>
+        /// <returns>true if the notification succeeded.</returns>
+        [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
+        public static extern bool DokanNotifyCreate([MarshalAs(UnmanagedType.LPWStr)] string FilePath,
+                                                    [MarshalAs(UnmanagedType.Bool)] bool isDirectory);
+
+        /// <summary>
+        /// Notify Dokan that a file or directory has been deleted.
+        /// </summary>
+        /// <param name="FilePath">Full path to the file or directory, including mount point.</param>
+        /// <param name="isDirectory">Indicates if the path is a directory.</param>
+        /// <returns>true if notification succeeded.</returns>
+        [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
+        public static extern bool DokanNotifyDelete([MarshalAs(UnmanagedType.LPWStr)] string FilePath,
+                                                    [MarshalAs(UnmanagedType.Bool)] bool isDirectory);
+
+        /// <summary>
+        /// Notify Dokan that file or directory attributes have changed.
+        /// </summary>
+        /// <param name="FilePath">Full path to the file or directory, including mount point.</param>
+        /// <returns>true if notification succeeded.</returns>
+        [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
+        public static extern bool DokanNotifyUpdate([MarshalAs(UnmanagedType.LPWStr)] string FilePath);
+
+        /// <summary>
+        /// Notify Dokan that file or directory extended attributes have changed.
+        /// </summary>
+        /// <param name="FilePath">Full path to the file or directory, including mount point.</param>
+        /// <returns>true if notification succeeded.</returns>
+        [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
+        public static extern bool DokanNotifyXAttrUpdate([MarshalAs(UnmanagedType.LPWStr)] string FilePath);
+
+        /// <summary>
+        /// Notify Dokan that a file or directory has been renamed.
+        /// </summary>
+        /// <remarks>This method supports in-place rename for file/directory within the same parent.</remarks>
+        /// <param name="OldPath">Old path to the file or directory, including mount point.</param>
+        /// <param name="NewPath">New path to the file or directory, including mount point.</param>
+        /// <param name="isDirectory">Indicates if the path is a directory.</param>
+        /// <param name="isInSameDirectory">Indicates if OldPath and NewPath have the same parent.</param>
+        /// <returns>true if notification succeeded.</returns>
+        [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
+        public static extern bool DokanNotifyRename([MarshalAs(UnmanagedType.LPWStr)] string OldPath,
+                                                    [MarshalAs(UnmanagedType.LPWStr)] string NewPath,
+                                                    [MarshalAs(UnmanagedType.Bool)] bool isDirectory,
+                                                    [MarshalAs(UnmanagedType.Bool)] bool isInSameDirectory);
+
     }
 }


### PR DESCRIPTION
Added methods to support dokany v1.3.0.1000's new kernel notifications, per #234.

The public dokannet interface for these requires passing the DokanFileInfo that the DokanOperations methods receive, so that the filenames passed can be in the same form that the DokanOperations methods receive (where the root of the filesystem implemented is `@"\"`). This contrasts with the kernel notification functions, which require the full path (including the mountpoint) being part of the filename they're called with.  This means that we need to dig the mountpoint out of the DFI, since implementation classes don't usually track their own mountpoint. We do this with a new internal accessor DokanFileInfo.NativeDokanOptions that exposes the private member DokanFileInfo._dokan_context (which is an IntPtr that points to a DOKAN_OPTIONS structure, and thus not directly useful), so that the MountPoint member can be referenced from it.
