### PR TITLE
IDokanFileInfo is now the final parameter for IDokanOperations(Unsafe).

### DIFF
--- a/DokanNet.Tests/DokanOperationsFixture.cs
+++ b/DokanNet.Tests/DokanOperationsFixture.cs
@@ -24,6 +24,7 @@ namespace DokanNet.Tests
 
             public bool HasUnmatchedInvocations { get; set; }
 
+            #region Delegates
             private delegate TResult FuncOut2<in T1, T2, in T3, out TResult>(T1 arg1, out T2 arg2, T3 arg3);
 
             private delegate TResult FuncOut2<in T1, T2, in T3, in T4, out TResult>(T1 arg1, out T2 arg2, T3 arg3, T4 arg4);
@@ -37,9 +38,11 @@ namespace DokanNet.Tests
             private delegate TResult FuncOut3<in T1, in T2, T3, in T4, out TResult>(T1 arg1, T2 arg2, out T3 arg3, T4 arg4);
 
             protected delegate TResult FuncOut3<in T1, in T2, T3, in T4, in T5, out TResult>(T1 arg1, T2 arg2, out T3 arg3, T4 arg4, T5 arg5);
+            #endregion
 
+            #region private TryExecute overloads
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private void TryExecute(string fileName, DokanFileInfo info, Action<string, DokanFileInfo> func, string funcName, bool restrictCallingProcessId = true)
+            private void TryExecute(string fileName, IDokanFileInfo info, Action<string, IDokanFileInfo> func, string funcName, bool restrictCallingProcessId = true)
             {
                 if (restrictCallingProcessId && info.ProcessId != Process.GetCurrentProcess().Id)
                     return;
@@ -57,14 +60,14 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute(DokanFileInfo info, Func<DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute(IDokanFileInfo info, Func<IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                     return DokanResult.AccessDenied;
 
                 try
                 {
-                    return func(info);
+                    return func(info as DokanFileInfo);
                 }
                 catch (Exception ex)
                 {
@@ -76,7 +79,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute(string fileName, DokanFileInfo info, Func<string, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute(string fileName, IDokanFileInfo info, Func<string, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                     return DokanResult.AccessDenied;
@@ -95,7 +98,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<T>(string fileName, T arg, DokanFileInfo info, Func<string, T, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<T>(string fileName, T arg, IDokanFileInfo info, Func<string, T, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                     return DokanResult.AccessDenied;
@@ -114,7 +117,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<T1, T2>(string fileName, T1 arg1, T2 arg2, DokanFileInfo info, Func<string, T1, T2, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<T1, T2>(string fileName, T1 arg1, T2 arg2, IDokanFileInfo info, Func<string, T1, T2, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                     return DokanResult.AccessDenied;
@@ -133,7 +136,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<T1, T2, T3>(string fileName, T1 arg1, T2 arg2, T3 arg3, DokanFileInfo info, Func<string, T1, T2, T3, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<T1, T2, T3>(string fileName, T1 arg1, T2 arg2, T3 arg3, IDokanFileInfo info, Func<string, T1, T2, T3, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                     return DokanResult.AccessDenied;
@@ -152,7 +155,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<TIn, TOut>(string fileName, TIn argIn, out TOut argOut, DokanFileInfo info, FuncOut3<string, TIn, TOut, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<TIn, TOut>(string fileName, TIn argIn, out TOut argOut, IDokanFileInfo info, FuncOut3<string, TIn, TOut, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                 {
@@ -175,7 +178,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<TOut>(string fileName, out TOut argOut, DokanFileInfo info, FuncOut2<string, TOut, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<TOut>(string fileName, out TOut argOut, IDokanFileInfo info, FuncOut2<string, TOut, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                 {
@@ -198,7 +201,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<TOut, TIn>(string fileName, out TOut argOut, TIn argIn, DokanFileInfo info, FuncOut2<string, TOut, TIn, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<TOut, TIn>(string fileName, out TOut argOut, TIn argIn, IDokanFileInfo info, FuncOut2<string, TOut, TIn, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                 {
@@ -221,7 +224,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<TIn1, TOut, TIn2>(string fileName, TIn1 argIn1, out TOut argOut, TIn2 argIn2, DokanFileInfo info, FuncOut3<string, TIn1, TOut, TIn2, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<TIn1, TOut, TIn2>(string fileName, TIn1 argIn1, out TOut argOut, TIn2 argIn2, IDokanFileInfo info, FuncOut3<string, TIn1, TOut, TIn2, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                 {
@@ -244,7 +247,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<TOut1, TOut2, TOut3, TOut4>(out TOut1 argOut1, out TOut2 argOut2, out TOut3 argOut3, out TOut4 argOut4, DokanFileInfo info, FuncOut1234<TOut1, TOut2, TOut3, TOut4, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<TOut1, TOut2, TOut3, TOut4>(out TOut1 argOut1, out TOut2 argOut2, out TOut3 argOut3, out TOut4 argOut4, IDokanFileInfo info, FuncOut1234<TOut1, TOut2, TOut3, TOut4, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                 {
@@ -273,7 +276,7 @@ namespace DokanNet.Tests
             }
 
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus TryExecute<TOut1, TOut2, TOut3>(out TOut1 argOut1, out TOut2 argOut2, out TOut3 argOut3, DokanFileInfo info, FuncOut123<TOut1, TOut2, TOut3, DokanFileInfo, NtStatus> func, string funcName)
+            private NtStatus TryExecute<TOut1, TOut2, TOut3>(out TOut1 argOut1, out TOut2 argOut2, out TOut3 argOut3, IDokanFileInfo info, FuncOut123<TOut1, TOut2, TOut3, IDokanFileInfo, NtStatus> func, string funcName)
             {
                 if (info.ProcessId != Process.GetCurrentProcess().Id)
                 {
@@ -298,81 +301,183 @@ namespace DokanNet.Tests
                     return DokanResult.InvalidParameter;
                 }
             }
+            #endregion
 
-            public void Cleanup(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.Cleanup(f, i), nameof(Cleanup), false);
+            #region IDokanOperations members
+            public void Cleanup(string fileName, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                TryExecute(fileName, (IDokanFileInfo)info, (f, i) => Target.Cleanup(f, i), nameof(Cleanup), false);
+            }
 
-            public void CloseFile(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.CloseFile(f, i), nameof(CloseFile), false);
+            public void CloseFile(string fileName, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                TryExecute(fileName, (IDokanFileInfo)info, (f, i) => Target.CloseFile(f, i), nameof(CloseFile), false);
+            }
 
-            public NtStatus CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.CreateFile(f, access, share, mode, options, attributes, i), nameof(CreateFile));
+            public NtStatus CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, (IDokanFileInfo)info, (f, i) => Target.CreateFile(f, access, share, mode, options, attributes, i), nameof(CreateFile));
+            }
 
-            public NtStatus DeleteDirectory(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.DeleteDirectory(f, i), nameof(DeleteDirectory));
+            public NtStatus DeleteDirectory(string fileName, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, (IDokanFileInfo)info, (f, i) => Target.DeleteDirectory(f, i), nameof(DeleteDirectory));
+            }
 
-            public NtStatus DeleteFile(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.DeleteFile(f, i), nameof(DeleteFile));
+            public NtStatus DeleteFile(string fileName, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, (IDokanFileInfo)info, (f, i) => Target.DeleteFile(f, i), nameof(DeleteFile));
+            }
 
-            public NtStatus FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info)
-                => TryExecute(fileName, out files, info, (string f, out IList<FileInformation> o, DokanFileInfo i) => Target.FindFiles(f, out o, i), nameof(FindFiles));
+            public NtStatus FindFiles(string fileName, out IList<FileInformation> files, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, out files, (IDokanFileInfo)info, (string f, out IList<FileInformation> o, IDokanFileInfo i) => Target.FindFiles(f, out o, i), nameof(FindFiles));
+            }
 
-            public NtStatus FindFilesWithPattern(string fileName, string searchPattern, out IList<FileInformation> files, DokanFileInfo info)
-                => TryExecute(fileName, searchPattern, out files, info, (string f, string s, out IList<FileInformation> o, DokanFileInfo i) => Target.FindFilesWithPattern(f, s, out o, i), nameof(FindFilesWithPattern));
+            public NtStatus FindFilesWithPattern(string fileName, string searchPattern, out IList<FileInformation> files, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, searchPattern, out files, (IDokanFileInfo)info, (string f, string s, out IList<FileInformation> o, IDokanFileInfo i) => Target.FindFilesWithPattern(f, s, out o, i), nameof(FindFilesWithPattern));
+            }
 
-            public NtStatus FindStreams(string fileName, out IList<FileInformation> streams, DokanFileInfo info)
-                => TryExecute(fileName, out streams, info, (string f, out IList<FileInformation> o, DokanFileInfo i) => Target.FindStreams(f, out o, i), nameof(FindStreams));
+            public NtStatus FindStreams(string fileName, out IList<FileInformation> streams, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, out streams, (IDokanFileInfo)info, (string f, out IList<FileInformation> o, IDokanFileInfo i) => Target.FindStreams(f, out o, i), nameof(FindStreams));
+            }
 
-            public NtStatus FlushFileBuffers(string fileName, DokanFileInfo info)
-                => TryExecute(fileName, info, (f, i) => Target.FlushFileBuffers(f, i), nameof(FlushFileBuffers));
+            public NtStatus FlushFileBuffers(string fileName, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, (IDokanFileInfo)info, (f, i) => Target.FlushFileBuffers(f, i), nameof(FlushFileBuffers));
+            }
 
-            public NtStatus GetDiskFreeSpace(out long freeBytesAvailable, out long totalNumberOfBytes, out long totalNumberOfFreeBytes, DokanFileInfo info)
-                => TryExecute(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, info, (out long a, out long t, out long f, DokanFileInfo i) => Target.GetDiskFreeSpace(out a, out t, out f, i), nameof(GetDiskFreeSpace));
+            public NtStatus GetDiskFreeSpace(out long freeBytesAvailable, out long totalNumberOfBytes, out long totalNumberOfFreeBytes, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, (IDokanFileInfo)info, (out long a, out long t, out long f, IDokanFileInfo i) => Target.GetDiskFreeSpace(out a, out t, out f, i), nameof(GetDiskFreeSpace));
+            }
 
-            public NtStatus GetFileInformation(string fileName, out FileInformation fileInfo, DokanFileInfo info)
-                => TryExecute(fileName, out fileInfo, info, (string f, out FileInformation fi, DokanFileInfo i) => Target.GetFileInformation(f, out fi, i), nameof(GetFileInformation));
+            public NtStatus GetFileInformation(string fileName, out FileInformation fileInfo, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, out fileInfo, (IDokanFileInfo)info, (string f, out FileInformation fi, IDokanFileInfo i) => Target.GetFileInformation(f, out fi, i), nameof(GetFileInformation));
+            }
 
-            public NtStatus GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
-                => TryExecute(fileName, out security, sections, info, (string f, out FileSystemSecurity s, AccessControlSections a, DokanFileInfo i) => Target.GetFileSecurity(f, out s, a, i), nameof(GetFileSecurity));
+            public NtStatus GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, out security, sections, (IDokanFileInfo)info, (string f, out FileSystemSecurity s, AccessControlSections a, IDokanFileInfo i) => Target.GetFileSecurity(f, out s, a, i), nameof(GetFileSecurity));
+            }
 
-            public NtStatus GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features, out string fileSystemName, out uint maximumComponentLength, DokanFileInfo info)
-                => TryExecute(out volumeLabel, out features, out fileSystemName, out maximumComponentLength, info, (out string v, out FileSystemFeatures f, out string n, out uint c, DokanFileInfo i) => Target.GetVolumeInformation(out v, out f, out n, out c, i), nameof(GetVolumeInformation));
+            public NtStatus GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features, out string fileSystemName, out uint maximumComponentLength, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(out volumeLabel, out features, out fileSystemName, out maximumComponentLength, (IDokanFileInfo)info, (out string v, out FileSystemFeatures f, out string n, out uint c, IDokanFileInfo i) => Target.GetVolumeInformation(out v, out f, out n, out c, i), nameof(GetVolumeInformation));
+            }
 
-            public NtStatus LockFile(string fileName, long offset, long length, DokanFileInfo info)
-                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.LockFile(f, o, l, i), nameof(LockFile));
+            public NtStatus LockFile(string fileName, long offset, long length, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, offset, length, (IDokanFileInfo)info, (f, o, l, i) => Target.LockFile(f, o, l, i), nameof(LockFile));
+            }
 
-            public NtStatus MoveFile(string oldName, string newName, bool replace, DokanFileInfo info)
-                => TryExecute(oldName, newName, replace, info, (o, n, r, i) => Target.MoveFile(o, n, r, i), nameof(MoveFile));
+            public NtStatus MoveFile(string oldName, string newName, bool replace, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(oldName, newName, replace, (IDokanFileInfo)info, (o, n, r, i) => Target.MoveFile(o, n, r, i), nameof(MoveFile));
+            }
 
-            public NtStatus ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, DokanFileInfo info)
-                => TryExecute(fileName, buffer, out bytesRead, offset, info, (string f, byte[] b, out int r, long o, DokanFileInfo i) => Target.ReadFile(f, b, out r, o, i), nameof(ReadFile));
+            public NtStatus ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, buffer, out bytesRead, offset, (IDokanFileInfo)info, (string f, byte[] b, out int r, long o, IDokanFileInfo i) => Target.ReadFile(f, b, out r, o, i), nameof(ReadFile));
+            }
 
-            public NtStatus SetAllocationSize(string fileName, long length, DokanFileInfo info)
-                => TryExecute(fileName, length, info, (f, l, i) => Target.SetAllocationSize(f, l, i), nameof(SetAllocationSize));
+            public NtStatus SetAllocationSize(string fileName, long length, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, length, (IDokanFileInfo)info, (f, l, i) => Target.SetAllocationSize(f, l, i), nameof(SetAllocationSize));
+            }
 
-            public NtStatus SetEndOfFile(string fileName, long length, DokanFileInfo info)
-                => TryExecute(fileName, length, info, (f, l, i) => Target.SetEndOfFile(f, l, i), nameof(SetEndOfFile));
+            public NtStatus SetEndOfFile(string fileName, long length, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, length, (IDokanFileInfo)info, (f, l, i) => Target.SetEndOfFile(f, l, i), nameof(SetEndOfFile));
+            }
 
-            public NtStatus SetFileAttributes(string fileName, FileAttributes attributes, DokanFileInfo info)
-                => TryExecute(fileName, attributes, info, (f, a, i) => Target.SetFileAttributes(f, a, i), nameof(SetFileAttributes));
+            public NtStatus SetFileAttributes(string fileName, FileAttributes attributes, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, attributes, (IDokanFileInfo)info, (f, a, i) => Target.SetFileAttributes(f, a, i), nameof(SetFileAttributes));
+            }
 
-            public NtStatus SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
-                => TryExecute(fileName, security, sections, info, (f, s, a, i) => Target.SetFileSecurity(f, s, a, i), nameof(SetFileSecurity));
+            public NtStatus SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, security, sections, (IDokanFileInfo)info, (f, s, a, i) => Target.SetFileSecurity(f, s, a, i), nameof(SetFileSecurity));
+            }
 
-            public NtStatus SetFileTime(string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, DokanFileInfo info)
-                => TryExecute(fileName, creationTime, lastAccessTime, lastWriteTime, info, (f, c, a, w, i) => Target.SetFileTime(f, c, a, w, i), nameof(SetFileTime));
+            public NtStatus SetFileTime(string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, creationTime, lastAccessTime, lastWriteTime, (IDokanFileInfo)info, (f, c, a, w, i) => Target.SetFileTime(f, c, a, w, i), nameof(SetFileTime));
+            }
 
-            public NtStatus UnlockFile(string fileName, long offset, long length, DokanFileInfo info)
-                => TryExecute(fileName, offset, length, info, (f, o, l, i) => Target.UnlockFile(f, o, l, i), nameof(UnlockFile));
+            public NtStatus UnlockFile(string fileName, long offset, long length, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, offset, length, (IDokanFileInfo)info, (f, o, l, i) => Target.UnlockFile(f, o, l, i), nameof(UnlockFile));
+            }
 
-            public NtStatus Mounted(DokanFileInfo info)
-                => TryExecute(info, i => Target.Mounted(i), nameof(Mounted));
+            public NtStatus Mounted(IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute((IDokanFileInfo)info, i => Target.Mounted(i), nameof(Mounted));
+            }
 
-            public NtStatus Unmounted(DokanFileInfo info)
-                => TryExecute(info, i => Target.Unmounted(i), nameof(Unmounted));
-
-            public NtStatus WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info)
-                => TryExecute(fileName, buffer, out bytesWritten, offset, info, (string f, byte[] b, out int w, long o, DokanFileInfo i) => Target.WriteFile(f, b, out w, o, i), nameof(WriteFile));
+            public NtStatus Unmounted(IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute((IDokanFileInfo)info, i => Target.Unmounted(i), nameof(Unmounted));
+            }
+            public NtStatus WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return TryExecute(fileName, buffer, out bytesWritten, offset, (IDokanFileInfo)info, (string f, byte[] b, out int w, long o, IDokanFileInfo i) => Target.WriteFile(f, b, out w, o, i), nameof(WriteFile));
+            }
+            #endregion
         }
 
         /// <summary>
@@ -381,17 +486,26 @@ namespace DokanNet.Tests
         /// </summary>
         private class UnsafeProxy : Proxy, IDokanOperationsUnsafe
         {
-            public NtStatus ReadFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesRead, long offset, DokanFileInfo info)
-                => MarshalUnsafeCall(fileName, buffer, bufferLength, out bytesRead, offset, info,
-                    (string f, byte[] buf, out int r, long o, DokanFileInfo i) => base.ReadFile(f, buf, out r, o, i));
+            public NtStatus ReadFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesRead, long offset, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return MarshalUnsafeCall(fileName, buffer, bufferLength, out bytesRead, offset, (IDokanFileInfo)info,
+                    (string f, byte[] buf, out int r, long o, IDokanFileInfo i) => base.ReadFile(f, buf, out r, o, i));
+            }
 
-            public NtStatus WriteFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesWritten, long offset, DokanFileInfo info)
-                => MarshalUnsafeCall(fileName, buffer, bufferLength, out bytesWritten, offset, info,
-                    (string f, byte[] buf, out int r, long o, DokanFileInfo i) => base.WriteFile(f, buf, out r, o, i));
+            public NtStatus WriteFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesWritten, long offset, IDokanFileInfo info)
+            {
+                if (!(info is IDokanFileInfo))
+                    throw new ArgumentException("Not IDokanFileInfo", nameof(info));
+                return MarshalUnsafeCall(fileName, buffer, bufferLength, out bytesWritten, offset, (IDokanFileInfo)info,
+                    (string f, byte[] buf, out int r, long o, IDokanFileInfo i) => base.WriteFile(f, buf, out r, o, i));
+            }
 
+            #region MarshalUnsafeCall implementation
             [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Explicit Exception handler")]
-            private NtStatus MarshalUnsafeCall(string fileName, IntPtr nativeBuffer, uint bufferLength, out int bytes, long offset, DokanFileInfo info,
-                FuncOut3<string, byte[], int, long, DokanFileInfo, NtStatus> func)
+            private NtStatus MarshalUnsafeCall(string fileName, IntPtr nativeBuffer, uint bufferLength, out int bytes, long offset, IDokanFileInfo info,
+                FuncOut3<string, byte[], int, long, IDokanFileInfo, NtStatus> func)
             {
                 byte[] managedBuffer = new byte[bufferLength];
                 Marshal.Copy(source: nativeBuffer, destination: managedBuffer, startIndex: 0, length: (int)bufferLength);
@@ -399,6 +513,7 @@ namespace DokanNet.Tests
                 Marshal.Copy(source: managedBuffer, startIndex: 0, destination: nativeBuffer, length: (int)bufferLength);
                 return result;
             }
+            #endregion
         }
 
         /// <summary>The mount point in use for the <see cref="IDokanOperations"/> implementation.</summary>
@@ -643,7 +758,7 @@ namespace DokanNet.Tests
         internal static int NumberOfChunks(long bufferSize, long fileSize)
         {
             var quotient = Math.DivRem(fileSize, bufferSize, out long remainder);
-            return (int) quotient + (remainder > 0 ? 1 : 0);
+            return (int)quotient + (remainder > 0 ? 1 : 0);
         }
 
         internal static string DriveBasedPath(string fileName)
@@ -673,7 +788,7 @@ namespace DokanNet.Tests
         internal static void ClearInstance(out bool hasUnmatchedInvocations)
         {
             // Allow pending calls to process
-            Thread.Sleep(2);
+            Thread.Sleep(1);
 
             Proxy proxyInUse = MOUNT_POINT == UnsafeMountPoint ? unsafeProxy : proxy;
             hasUnmatchedInvocations = proxyInUse.HasUnmatchedInvocations;
@@ -692,7 +807,7 @@ namespace DokanNet.Tests
         internal static void InitSecurity()
         {
             var sid = WindowsIdentity.GetCurrent();
-            
+
             var sidRights = "O:" + sid.User + "G:" + sid.Groups[0];
 
             DefaultDirectorySecurity = new DirectorySecurity();
@@ -700,7 +815,7 @@ namespace DokanNet.Tests
 
             DefaultFileSecurity = new FileSecurity();
             DefaultFileSecurity.SetSecurityDescriptorSddlForm(sidRights + "D:AI(A;ID;FA;;;AU)");
-         }
+        }
 
         internal static IList<FileInformation> GetEmptyDirectoryDefaultFiles()
             => new[]
@@ -722,17 +837,20 @@ namespace DokanNet.Tests
             return fileInformations
                 .Select(x => new FileInformation()
                 {
-                    FileName = x.FileName, Attributes = x.Attributes,
-                    CreationTime = null, LastAccessTime = null, LastWriteTime = null,
+                    FileName = x.FileName,
+                    Attributes = x.Attributes,
+                    CreationTime = null,
+                    LastAccessTime = null,
+                    LastWriteTime = null,
                     Length = x.Length
                 }).ToArray();
         }
 
         internal static byte[] InitPeriodicTestData(long fileSize)
-            => Enumerable.Range(0, (int) fileSize).Select(i => (byte) (i%251)).ToArray();
+            => Enumerable.Range(0, (int)fileSize).Select(i => (byte)(i % 251)).ToArray();
 
         internal static byte[] InitBlockTestData(long bufferSize, long fileSize)
-            => Enumerable.Range(0, (int) fileSize).Select(i => (byte) (i/bufferSize + 1)).ToArray();
+            => Enumerable.Range(0, (int)fileSize).Select(i => (byte)(i / bufferSize + 1)).ToArray();
 
         public DokanOperationsFixture(string currentTestName)
         {
@@ -750,12 +868,15 @@ namespace DokanNet.Tests
 
         private FileInformation Named(FileInformation info) => new FileInformation()
         {
-            FileName = Named(info.FileName), Attributes = info.Attributes,
-            CreationTime = info.CreationTime, LastAccessTime = info.LastAccessTime, LastWriteTime = info.LastWriteTime,
+            FileName = Named(info.FileName),
+            Attributes = info.Attributes,
+            CreationTime = info.CreationTime,
+            LastAccessTime = info.LastAccessTime,
+            LastWriteTime = info.LastWriteTime,
             Length = info.Length
         };
 
-        private static Func<DokanFileInfo, bool> FilterByIsDirectory(bool? isDirectory)
+        private static Func<IDokanFileInfo, bool> FilterByIsDirectory(bool? isDirectory)
             => f => !isDirectory.HasValue || f.IsDirectory == isDirectory.Value;
 
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
@@ -765,88 +886,94 @@ namespace DokanNet.Tests
         internal void PermitAny()
         {
             operations
-                .Setup(d => d.Cleanup(It.IsAny<string>(), It.IsAny<DokanFileInfo>()))
-                .Callback((string fileName, DokanFileInfo info)
+                .Setup(d => d.Cleanup(It.IsAny<string>(), It.IsAny<IDokanFileInfo>()))
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.Cleanup)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
 
             operations
-                .Setup(d => d.CloseFile(It.IsAny<string>(), It.IsAny<DokanFileInfo>()))
-                .Callback((string fileName, DokanFileInfo info)
+                .Setup(d => d.CloseFile(It.IsAny<string>(), It.IsAny<IDokanFileInfo>()))
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.CloseFile)}[{Interlocked.Decrement(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
 
             operations
-                .Setup(d => d.CreateFile(It.IsAny<string>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>(), It.IsAny<FileMode>(), It.IsAny<FileOptions>(), It.IsAny<FileAttributes>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.CreateFile(It.IsAny<string>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>(), It.IsAny<FileMode>(), It.IsAny<FileOptions>(), It.IsAny<FileAttributes>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Increment(ref pendingFiles)}] (\"{fileName}\", [{access}], [{share}], {mode}, [{options}], [{attributes}], {info.Log()})"));
 
             operations
-                .Setup(d => d.DeleteDirectory(It.IsAny<string>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.DeleteDirectory(It.IsAny<string>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info)
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.DeleteDirectory)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
 
             operations
-                .Setup(d => d.DeleteFile(It.IsAny<string>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.DeleteFile(It.IsAny<string>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info)
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.DeleteFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
 
             var files = GetEmptyDirectoryDefaultFiles();
             operations
-                .Setup(d => d.FindFiles(It.IsAny<string>(), out files, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.FindFiles(It.IsAny<string>(), out files, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, IList<FileInformation> _files, DokanFileInfo info)
+                .Callback((string fileName, IList<FileInformation> _files, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FindFiles)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_files.Count}], {info.Log()})"));
 
             operations
-                .Setup(d => d.FlushFileBuffers(It.IsAny<string>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.FlushFileBuffers(It.IsAny<string>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info)
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FlushFileBuffers)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
 
             long freeBytesAvailable = 0;
             long totalNumberOfBytes = 0;
             long totalNumberOfFreeBytes = 0;
             operations
-                .Setup(d => d.GetDiskFreeSpace(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.GetDiskFreeSpace(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((long _freeBytesAvailable, long _totalNumberOfBytes, long _totalNumberOfFreeBytes, DokanFileInfo info)
+                .Callback((long _freeBytesAvailable, long _totalNumberOfBytes, long _totalNumberOfFreeBytes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetDiskFreeSpace)}[{Interlocked.Read(ref pendingFiles)}] (out {_freeBytesAvailable}, out {_totalNumberOfBytes}, out {_totalNumberOfFreeBytes}, {info.Log()})"));
 
             var directoryInfo = new FileInformation()
             {
-                FileName = "DummyDir", Attributes = FileAttributes.Directory,
-                CreationTime = new DateTime(2015, 1, 1, 12, 0, 0), LastWriteTime = new DateTime(2015, 3, 31, 12, 0, 0), LastAccessTime = new DateTime(2015, 5, 31, 12, 0, 0)
+                FileName = "DummyDir",
+                Attributes = FileAttributes.Directory,
+                CreationTime = new DateTime(2015, 1, 1, 12, 0, 0),
+                LastWriteTime = new DateTime(2015, 3, 31, 12, 0, 0),
+                LastAccessTime = new DateTime(2015, 5, 31, 12, 0, 0)
             };
             operations
-                .Setup(d => d.GetFileInformation(It.IsAny<string>(), out directoryInfo, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.GetFileInformation(It.IsAny<string>(), out directoryInfo, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileInformation _directoryInfo, DokanFileInfo info)
+                .Callback((string fileName, FileInformation _directoryInfo, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileInformation)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_directoryInfo.Log()}], {info.Log()})"));
             var fileInfo = new FileInformation()
             {
-                FileName = "Dummy.ext", Attributes = FileAttributes.Normal,
-                CreationTime = new DateTime(2015, 1, 1, 12, 0, 0), LastWriteTime = new DateTime(2015, 3, 31, 12, 0, 0), LastAccessTime = new DateTime(2015, 5, 31, 12, 0, 0),
+                FileName = "Dummy.ext",
+                Attributes = FileAttributes.Normal,
+                CreationTime = new DateTime(2015, 1, 1, 12, 0, 0),
+                LastWriteTime = new DateTime(2015, 3, 31, 12, 0, 0),
+                LastAccessTime = new DateTime(2015, 5, 31, 12, 0, 0),
                 Length = 1024
             };
             operations
-                .Setup(d => d.GetFileInformation(It.IsAny<string>(), out fileInfo, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.GetFileInformation(It.IsAny<string>(), out fileInfo, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileInformation _fileInfo, DokanFileInfo info)
+                .Callback((string fileName, FileInformation _fileInfo, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileInformation)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_fileInfo.Log()}], {info.Log()})"));
 
             var fileSecurity = new FileSecurity() as FileSystemSecurity;
             operations
-                .Setup(d => d.GetFileSecurity(It.IsAny<string>(), out fileSecurity, It.IsAny<AccessControlSections>(), It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.GetFileSecurity(It.IsAny<string>(), out fileSecurity, It.IsAny<AccessControlSections>(), It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileSystemSecurity _fileSecurity, AccessControlSections sections, DokanFileInfo info)
+                .Callback((string fileName, FileSystemSecurity _fileSecurity, AccessControlSections sections, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileSecurity)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out {_fileSecurity}, {sections}, {info.Log()})"));
             var directorySecurity = new DirectorySecurity() as FileSystemSecurity;
             operations
-                .Setup(d => d.GetFileSecurity(It.IsAny<string>(), out directorySecurity, It.IsAny<AccessControlSections>(), It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.GetFileSecurity(It.IsAny<string>(), out directorySecurity, It.IsAny<AccessControlSections>(), It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileSystemSecurity _directorySecurity, AccessControlSections sections, DokanFileInfo info)
+                .Callback((string fileName, FileSystemSecurity _directorySecurity, AccessControlSections sections, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileSecurity)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out {_directorySecurity}, {sections}, {info.Log()})"));
 
             var volumeLabel = VOLUME_LABEL;
@@ -854,83 +981,83 @@ namespace DokanNet.Tests
             var fileSystemName = FILESYSTEM_NAME;
             uint maximumComponentLength = 256;
             operations
-                .Setup(d => d.GetVolumeInformation(out volumeLabel, out features, out fileSystemName, out maximumComponentLength, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.GetVolumeInformation(out volumeLabel, out features, out fileSystemName, out maximumComponentLength, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string _volumeLabel, FileSystemFeatures _features, string _fileSystemName, uint _maximumComponentLength, DokanFileInfo info)
+                .Callback((string _volumeLabel, FileSystemFeatures _features, string _fileSystemName, uint _maximumComponentLength, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetVolumeInformation)}[{Interlocked.Read(ref pendingFiles)}] (out \"{_volumeLabel}\", out [{_features}], out \"{_fileSystemName}\", out \"{_maximumComponentLength}\", {info.Log()})"));
 
             operations
-                .Setup(d => d.LockFile(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.LockFile(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long offset, long length, DokanFileInfo info)
+                .Callback((string fileName, long offset, long length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.LockFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {offset}, {length}, {info.Log()})"));
 
             operations
-                .Setup(d => d.MoveFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.MoveFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string oldName, string newName, bool replace, DokanFileInfo info)
+                .Callback((string oldName, string newName, bool replace, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.MoveFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{oldName}\", \"{newName}\", {replace}, {info.Log()})"));
 
             var bytesRead = 0;
             operations
-                .Setup(d => d.ReadFile(It.IsAny<string>(), It.IsAny<byte[]>(), out bytesRead, It.IsAny<long>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.ReadFile(It.IsAny<string>(), It.IsAny<byte[]>(), out bytesRead, It.IsAny<long>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, byte[] buffer, int _bytesRead, long offset, DokanFileInfo info)
+                .Callback((string fileName, byte[] buffer, int _bytesRead, long offset, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.ReadFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{buffer.Length}], out {_bytesRead}, {offset}, {info.Log()})"));
 
             operations
-                .Setup(d => d.SetAllocationSize(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.SetAllocationSize(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long length, DokanFileInfo info)
+                .Callback((string fileName, long length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetAllocationSize)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {length}, {info.Log()})"));
 
             operations
-                .Setup(d => d.SetEndOfFile(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.SetEndOfFile(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long length, DokanFileInfo info)
+                .Callback((string fileName, long length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetEndOfFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {length}, {info.Log()})"));
 
             operations
-                .Setup(d => d.SetFileAttributes(It.IsAny<string>(), It.IsAny<FileAttributes>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.SetFileAttributes(It.IsAny<string>(), It.IsAny<FileAttributes>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileAttributes attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAttributes attributes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetFileAttributes)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{attributes}], {info.Log()})"));
 
             operations
-                .Setup(d => d.SetFileSecurity(It.IsAny<string>(), It.IsAny<FileSystemSecurity>(), It.IsAny<AccessControlSections>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.SetFileSecurity(It.IsAny<string>(), It.IsAny<FileSystemSecurity>(), It.IsAny<AccessControlSections>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileSystemSecurity security, AccessControlSections sections, DokanFileInfo info)
+                .Callback((string fileName, FileSystemSecurity security, AccessControlSections sections, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetFileSecurity)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{security}], {sections}, {info.Log()})"));
 
             operations
-                .Setup(d => d.SetFileTime(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.SetFileTime(It.IsAny<string>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, DokanFileInfo info)
+                .Callback((string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetFileTime)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {creationTime}, {lastAccessTime}, {lastWriteTime}, {info.Log()})"));
 
             operations
-                .Setup(d => d.UnlockFile(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.UnlockFile(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long offset, long length, DokanFileInfo info)
+                .Callback((string fileName, long offset, long length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.UnlockFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {offset}, {length}, {info.Log()})"));
 
             operations
-                .Setup(d => d.Mounted(It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.Mounted(It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((DokanFileInfo info)
+                .Callback((IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.Mounted)}[{Interlocked.Read(ref pendingFiles)}] ({info.Log()})"));
 
             operations
-                .Setup(d => d.Unmounted(It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.Unmounted(It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((DokanFileInfo info)
+                .Callback((IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.Unmounted)}[{Interlocked.Read(ref pendingFiles)}] ({info.Log()})"));
 
             var bytesWritten = 0;
             operations
-                .Setup(d => d.WriteFile(It.IsAny<string>(), It.IsAny<byte[]>(), out bytesWritten, It.IsAny<long>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.WriteFile(It.IsAny<string>(), It.IsAny<byte[]>(), out bytesWritten, It.IsAny<long>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, byte[] buffer, int _bytesWritten, long offset, DokanFileInfo info)
+                .Callback((string fileName, byte[] buffer, int _bytesWritten, long offset, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.WriteFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{buffer.Length}], out {_bytesWritten}, {offset}, {info.Log()})"));
         }
 
@@ -938,32 +1065,35 @@ namespace DokanNet.Tests
         private void PermitMount()
         {
             operations
-                .Setup(d => d.Mounted(It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.Mounted(It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((DokanFileInfo info)
+                .Callback((IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.Mounted)} {info.Log()}"));
             operations
-                .Setup(d => d.CreateFile(RootName, FileAccess.ReadAttributes, ReadWriteShare, FileMode.Open, FileOptions.None, EmptyFileAttributes, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.CreateFile(RootName, FileAccess.ReadAttributes, ReadWriteShare, FileMode.Open, FileOptions.None, EmptyFileAttributes, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Increment(ref pendingFiles)}] (\"{fileName}\", [{access}], [{share}], {mode}, [{options}], [{attributes}], {info.Log()})"));
             var fileInfo = new FileInformation()
             {
-                FileName = RootName, Attributes = FileAttributes.Directory,
-                CreationTime = new DateTime(2015, 1, 1, 12, 0, 0), LastWriteTime = new DateTime(2015, 3, 31, 12, 0, 0), LastAccessTime = new DateTime(2015, 3, 31, 12, 0, 0)
+                FileName = RootName,
+                Attributes = FileAttributes.Directory,
+                CreationTime = new DateTime(2015, 1, 1, 12, 0, 0),
+                LastWriteTime = new DateTime(2015, 3, 31, 12, 0, 0),
+                LastAccessTime = new DateTime(2015, 3, 31, 12, 0, 0)
             };
             operations
-                .Setup(d => d.GetFileInformation(RootName, out fileInfo, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.GetFileInformation(RootName, out fileInfo, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileInformation _fileInfo, DokanFileInfo info)
+                .Callback((string fileName, FileInformation _fileInfo, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileInformation)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_fileInfo.Log()}], {info.Log()})"));
             operations
-                .Setup(d => d.Cleanup(RootName, It.IsAny<DokanFileInfo>()))
-                .Callback((string fileName, DokanFileInfo info)
+                .Setup(d => d.Cleanup(RootName, It.IsAny<IDokanFileInfo>()))
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.Cleanup)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
             operations
-                .Setup(d => d.CloseFile(RootName, It.IsAny<DokanFileInfo>()))
-                .Callback((string fileName, DokanFileInfo info)
+                .Setup(d => d.CloseFile(RootName, It.IsAny<IDokanFileInfo>()))
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.CloseFile)}[{Interlocked.Decrement(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"));
         }
 
@@ -973,9 +1103,9 @@ namespace DokanNet.Tests
             ExpectOpenDirectory(RootName, OpenDirectoryAccess, OpenDirectoryShare);
 
             operations
-                .Setup(d => d.GetDiskFreeSpace(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.GetDiskFreeSpace(out freeBytesAvailable, out totalNumberOfBytes, out totalNumberOfFreeBytes, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((long _freeBytesAvailable, long _totalNumberOfBytes, long _totalNumberOfFreeBytes, DokanFileInfo info)
+                .Callback((long _freeBytesAvailable, long _totalNumberOfBytes, long _totalNumberOfFreeBytes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetDiskFreeSpace)}[{Interlocked.Read(ref pendingFiles)}] (out {_freeBytesAvailable}, out {_totalNumberOfBytes}, out {_totalNumberOfFreeBytes}, {info.Log()})"))
                 .Verifiable();
         }
@@ -984,9 +1114,9 @@ namespace DokanNet.Tests
         {
             var features = TestFileSystemFeatures;
             operations
-                .Setup(d => d.GetVolumeInformation(out volumeLabel, out features, out fileSystemName, out maximumComponentLength, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.GetVolumeInformation(out volumeLabel, out features, out fileSystemName, out maximumComponentLength, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string _volumeLabel, FileSystemFeatures _features, string _fileSystemName, uint _maximumComponentLength, DokanFileInfo info)
+                .Callback((string _volumeLabel, FileSystemFeatures _features, string _fileSystemName, uint _maximumComponentLength, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetVolumeInformation)}[{Interlocked.Read(ref pendingFiles)}] (out \"{_volumeLabel}\", out [{_features}], out \"{_fileSystemName}\", out \"{_maximumComponentLength}\", {info.Log()})"))
                 .Verifiable();
         }
@@ -995,14 +1125,17 @@ namespace DokanNet.Tests
         {
             var fileInfo = new FileInformation()
             {
-                FileName = path, Attributes = attributes,
-                CreationTime = creationTime, LastWriteTime = lastWriteTime, LastAccessTime = lastAccessTime,
+                FileName = path,
+                Attributes = attributes,
+                CreationTime = creationTime,
+                LastWriteTime = lastWriteTime,
+                LastAccessTime = lastAccessTime,
                 Length = length ?? 0
             };
             return operations
-                .Setup(d => d.GetFileInformation(path, out fileInfo, It.Is<DokanFileInfo>(i => FilterByIsDirectory(isDirectory)(i))))
+                .Setup(d => d.GetFileInformation(path, out fileInfo, It.Is<IDokanFileInfo>(i => FilterByIsDirectory(isDirectory)(i))))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileInformation _fileInfo, DokanFileInfo info)
+                .Callback((string fileName, FileInformation _fileInfo, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileInformation)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_fileInfo.Log()}], {info.Log()})"));
         }
 
@@ -1024,9 +1157,9 @@ namespace DokanNet.Tests
 
             var fileInfo = default(FileInformation);
             return operations
-                .Setup(d => d.GetFileInformation(path, out fileInfo, It.Is<DokanFileInfo>(i => FilterByIsDirectory(isDirectory)(i))))
+                .Setup(d => d.GetFileInformation(path, out fileInfo, It.Is<IDokanFileInfo>(i => FilterByIsDirectory(isDirectory)(i))))
                 .Returns(result)
-                .Callback((string fileName, FileInformation _fileInfo, DokanFileInfo info)
+                .Callback((string fileName, FileInformation _fileInfo, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileInformation)}[{Interlocked.Read(ref pendingFiles)}] **{result}** (\"{fileName}\", out [{_fileInfo.Log()}], {info.Log()})"));
         }
 
@@ -1043,9 +1176,9 @@ namespace DokanNet.Tests
         internal void ExpectFindFiles(string path, IList<FileInformation> fileInfos)
         {
             operations
-                .Setup(d => d.FindFiles(path, out fileInfos, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.FindFiles(path, out fileInfos, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, IList<FileInformation> _files, DokanFileInfo info)
+                .Callback((string fileName, IList<FileInformation> _files, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FindFiles)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_files.Count}], {info.Log()})"))
                 .Verifiable();
         }
@@ -1053,9 +1186,9 @@ namespace DokanNet.Tests
         internal void ExpectFindFilesWithPattern(string path, string searchPattern, IList<FileInformation> fileInfos)
         {
             operations
-                .Setup(d => d.FindFilesWithPattern(path, searchPattern, out fileInfos, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.FindFilesWithPattern(path, searchPattern, out fileInfos, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, string _searchPattern, IList<FileInformation> _files, DokanFileInfo info)
+                .Callback((string fileName, string _searchPattern, IList<FileInformation> _files, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FindFilesWithPattern)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", \"{_searchPattern}\", out [{_files.Count}], {info.Log()})"))
                 .Verifiable();
         }
@@ -1064,9 +1197,9 @@ namespace DokanNet.Tests
         {
             var fileInfos = new List<FileInformation>() as IList<FileInformation>;
             operations
-                .Setup(d => d.FindFilesWithPattern(path, searchPattern, out fileInfos, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.FindFilesWithPattern(path, searchPattern, out fileInfos, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(result)
-                .Callback((string fileName, string _searchPattern, IList<FileInformation> _files, DokanFileInfo info)
+                .Callback((string fileName, string _searchPattern, IList<FileInformation> _files, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FindFilesWithPattern)}[{Interlocked.Read(ref pendingFiles)}] **{result}** (\"{fileName}\", \"{_searchPattern}\", out [{_files.Count}], {info.Log()})"))
                 .Verifiable();
         }
@@ -1074,9 +1207,9 @@ namespace DokanNet.Tests
         internal void ExpectOpenDirectoryWithoutCleanup(string path, FileAccess access = FileAccess.Synchronize, FileShare share = FileShare.None, FileAttributes attributes = EmptyFileAttributes)
         {
             operations
-                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, FileMode.Open, ReadFileOptions, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, FileMode.Open, ReadFileOptions, attributes, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode mode, FileOptions options, FileAttributes _attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode mode, FileOptions options, FileAttributes _attributes, IDokanFileInfo info)
                         => Trace($"{nameof(IDokanOperations.CreateFile)}-NoCleanup[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_access}], [{_share}], {mode}, [{options}], [{_attributes}], {info.Log()})"))
                 .Verifiable();
         }
@@ -1096,17 +1229,17 @@ namespace DokanNet.Tests
             return new[]
             {
                 operations
-                    .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                    .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                     .Returns(DokanResult.Success)
-                    .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, DokanFileInfo info)
+                    .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, IDokanFileInfo info)
                         => Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Increment(ref pendingFiles)}] (\"{fileName}\", [{_access}], [{_share}], {_mode}, [{_options}], [{_attributes}], {info.Log()})")),
                 operations
-                    .Setup(d => d.Cleanup(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
-                    .Callback((string fileName, DokanFileInfo info)
+                    .Setup(d => d.Cleanup(path, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
+                    .Callback((string fileName, IDokanFileInfo info)
                         => Trace($"{nameof(IDokanOperations.Cleanup)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})")),
                 operations
-                    .Setup(d => d.CloseFile(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
-                    .Callback((string fileName, DokanFileInfo info)
+                    .Setup(d => d.CloseFile(path, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
+                    .Callback((string fileName, IDokanFileInfo info)
                         => Trace($"{nameof(IDokanOperations.CloseFile)}[{Interlocked.Decrement(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"))
             };
         }
@@ -1131,9 +1264,9 @@ namespace DokanNet.Tests
                 throw new ArgumentException($"{DokanResult.Success} not supported", nameof(result));
 
             operations
-                .Setup(d => d.CreateFile(path, ReadDirectoryAccess, FileShare.ReadWrite, FileMode.CreateNew, It.IsAny<FileOptions>(), It.IsAny<FileAttributes>(), It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.CreateFile(path, ReadDirectoryAccess, FileShare.ReadWrite, FileMode.CreateNew, It.IsAny<FileOptions>(), It.IsAny<FileAttributes>(), It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(result)
-                .Callback((string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Increment(ref pendingFiles)}] **{result}** (\"{fileName}\", [{access}], [{share}], {mode}, [{options}], [{attributes}], {info.Log()})"))
                 .Verifiable();
 
@@ -1144,9 +1277,9 @@ namespace DokanNet.Tests
         internal void ExpectDeleteDirectory(string path)
         {
             operations
-                .Setup(d => d.DeleteDirectory(path, It.Is<DokanFileInfo>(i => i.IsDirectory)))
+                .Setup(d => d.DeleteDirectory(path, It.Is<IDokanFileInfo>(i => i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info)
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.DeleteDirectory)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"))
                 .Verifiable();
         }
@@ -1154,13 +1287,13 @@ namespace DokanNet.Tests
         private IVerifies SetupCreateFile(string path, FileAccess access, FileShare share, FileMode mode, FileOptions options = FileOptions.None, FileAttributes attributes = default(FileAttributes), object context = null, bool isDirectory = false)
         {
             return operations
-                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory)))
+                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<IDokanFileInfo>(i => i.IsDirectory == isDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, IDokanFileInfo info)
                     =>
                     {
                         info.Context = context;
-                        Trace( $"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Increment(ref pendingFiles)}] (\"{fileName}\", [{_access}], [{_share}], {_mode}, [{_options}], [{_attributes}], {info.Log()})");
+                        Trace($"{nameof(IDokanOperations.CreateFile)}[{Interlocked.Increment(ref pendingFiles)}] (\"{fileName}\", [{_access}], [{_share}], {_mode}, [{_options}], [{_attributes}], {info.Log()})");
                     });
         }
 
@@ -1181,9 +1314,9 @@ namespace DokanNet.Tests
         internal void ExpectCreateFileWithoutCleanup(string path, FileAccess access, FileShare share, FileMode mode, FileOptions options = FileOptions.None, FileAttributes attributes = default(FileAttributes), object context = null, bool isDirectory = false)
         {
             operations
-                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<DokanFileInfo>(i => i.IsDirectory == isDirectory)))
+                .Setup(d => d.CreateFile(path, FileAccessUtils.MapSpecificToGenericAccess(access), share, mode, options, attributes, It.Is<IDokanFileInfo>(i => i.IsDirectory == isDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions _options, FileAttributes _attributes, IDokanFileInfo info)
                     =>
                     {
                         info.Context = context;
@@ -1198,9 +1331,9 @@ namespace DokanNet.Tests
                 throw new ArgumentException($"{DokanResult.Success} not supported", nameof(result));
 
             operations
-                .Setup(d => d.CreateFile(path, It.IsAny<FileAccess>(), It.IsAny<FileShare>(), It.IsAny<FileMode>(), It.IsAny<FileOptions>(), It.IsAny<FileAttributes>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.CreateFile(path, It.IsAny<FileAccess>(), It.IsAny<FileShare>(), It.IsAny<FileMode>(), It.IsAny<FileOptions>(), It.IsAny<FileAttributes>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(result)
-                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions options, FileAttributes _attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAccess _access, FileShare _share, FileMode _mode, FileOptions options, FileAttributes _attributes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.CreateFile)}[{(closeFile ? Interlocked.Increment(ref pendingFiles) : Interlocked.Read(ref pendingFiles))}] **{result}** (\"{fileName}\", [{_access}], [{_share}], {_mode}, [{options}], [{_attributes}], {info.Log()})"))
                 .Verifiable();
 
@@ -1211,8 +1344,8 @@ namespace DokanNet.Tests
         internal void ExpectCleanupFile(string path, object context = null, bool isDirectory = false, bool deleteOnClose = false)
         {
             operations
-                .Setup(d => d.Cleanup(path, It.Is<DokanFileInfo>(i => i.Context == context && i.IsDirectory == isDirectory && i.DeleteOnClose == deleteOnClose)))
-                .Callback((string fileName, DokanFileInfo info)
+                .Setup(d => d.Cleanup(path, It.Is<IDokanFileInfo>(i => i.Context == context && i.IsDirectory == isDirectory && i.DeleteOnClose == deleteOnClose)))
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.Cleanup)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"))
                 .Verifiable();
 
@@ -1222,8 +1355,8 @@ namespace DokanNet.Tests
         internal void ExpectCloseFile(string path, object context = null, bool isDirectory = false, bool deleteOnClose = false)
         {
             operations
-                .Setup(d => d.CloseFile(path, It.Is<DokanFileInfo>(i => i.Context == context && i.IsDirectory == isDirectory && i.DeleteOnClose == deleteOnClose)))
-                .Callback((string fileName, DokanFileInfo info)
+                .Setup(d => d.CloseFile(path, It.Is<IDokanFileInfo>(i => i.Context == context && i.IsDirectory == isDirectory && i.DeleteOnClose == deleteOnClose)))
+                .Callback((string fileName, IDokanFileInfo info)
                     =>
                     {
                         Trace($"{nameof(IDokanOperations.CloseFile)}[{(isDirectory ? Interlocked.Read(ref pendingFiles) : Interlocked.Decrement(ref pendingFiles))}] (\"{fileName}\", {info.Log()})");
@@ -1235,9 +1368,9 @@ namespace DokanNet.Tests
         internal void ExpectFlushFileBuffers(string path)
         {
             operations
-                .Setup(d => d.FlushFileBuffers(path, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.FlushFileBuffers(path, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info)
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FlushFileBuffers)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"))
                 .Verifiable();
         }
@@ -1245,15 +1378,15 @@ namespace DokanNet.Tests
         internal void ExpectLockUnlockFile(string path, long offset, long length)
         {
             operations
-                .Setup(d => d.LockFile(path, offset, length, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.LockFile(path, offset, length, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long _offset, long _length, DokanFileInfo info)
+                .Callback((string fileName, long _offset, long _length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.LockFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {_offset}, {_length}, {info.Log()})"))
                 .Verifiable();
             operations
-                .Setup(d => d.UnlockFile(path, offset, length, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.UnlockFile(path, offset, length, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long _offset, long _length, DokanFileInfo info)
+                .Callback((string fileName, long _offset, long _length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.UnlockFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {_offset}, {_length}, {info.Log()})"))
                 .Verifiable();
         }
@@ -1261,9 +1394,9 @@ namespace DokanNet.Tests
         internal void PermitProbeFile(string path, byte[] buffer, int probeBufferSize = PROBE_BUFFER_SIZE)
         {
             operations
-                .Setup(d => d.ReadFile(path, It.Is<byte[]>(b => b.Length == probeBufferSize), out probeBufferSize, 0, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.ReadFile(path, It.Is<byte[]>(b => b.Length == probeBufferSize), out probeBufferSize, 0, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, DokanFileInfo info)
+                .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, IDokanFileInfo info)
                     =>
                     {
                         Array.ConstrainedCopy(buffer, 0, _buffer, 0, Math.Min(probeBufferSize, buffer.Length));
@@ -1275,9 +1408,9 @@ namespace DokanNet.Tests
             bool synchronousIo = true)
         {
             operations
-                .Setup(d => d.ReadFile(path, It.IsAny<byte[]>(), out bytesRead, 0, It.Is<DokanFileInfo>( i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
+                .Setup(d => d.ReadFile(path, It.IsAny<byte[]>(), out bytesRead, 0, It.Is<IDokanFileInfo>(i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, DokanFileInfo info)
+                .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, IDokanFileInfo info)
                     =>
                     {
                         Array.ConstrainedCopy(buffer, 0, _buffer, 0, Math.Min(bytesRead, _buffer.Length));
@@ -1289,10 +1422,10 @@ namespace DokanNet.Tests
         internal void ExpectReadFileWithDelay(string path, byte[] buffer, int bytesRead, TimeSpan delay)
         {
             operations
-                .Setup(d => d.ReadFile(path, It.IsAny<byte[]>(), out bytesRead, 0, It.Is<DokanFileInfo>(i => !i.IsDirectory && i.SynchronousIo)))
+                .Setup(d => d.ReadFile(path, It.IsAny<byte[]>(), out bytesRead, 0, It.Is<IDokanFileInfo>(i => !i.IsDirectory && i.SynchronousIo)))
                 .Callback(() => Thread.Sleep(delay))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, DokanFileInfo info)
+                .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, IDokanFileInfo info)
                     =>
                     {
                         Array.ConstrainedCopy(buffer, 0, _buffer, 0, Math.Min(bytesRead, _buffer.Length));
@@ -1311,13 +1444,13 @@ namespace DokanNet.Tests
                 var bytesRead = Math.Min(chunkSize, bytesRemaining);
                 operations
                     .Setup(d => d.ReadFile(path, It.Is<byte[]>(b => b.Length == chunkSize || b.Length == bytesRemaining), out bytesRead, offsets[index],
-                                It.Is<DokanFileInfo>(i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
+                                It.Is<IDokanFileInfo>(i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
                     .Returns(DokanResult.Success)
-                    .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, DokanFileInfo info)
+                    .Callback((string fileName, byte[] _buffer, int _bytesRead, long _offset, IDokanFileInfo info)
                         =>
                         {
-                            Array.ConstrainedCopy(buffer, (int) _offset, _buffer, 0, _bytesRead);
-                            Trace($"{nameof(IDokanOperations.ReadFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_buffer.Length}], {_buffer.Take(_bytesRead).SequenceEqual(buffer.Skip((int) _offset).Take(_bytesRead))}, out {_bytesRead}, {_offset}, {info.Log()})");
+                            Array.ConstrainedCopy(buffer, (int)_offset, _buffer, 0, _bytesRead);
+                            Trace($"{nameof(IDokanOperations.ReadFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_buffer.Length}], {_buffer.Take(_bytesRead).SequenceEqual(buffer.Skip((int)_offset).Take(_bytesRead))}, out {_bytesRead}, {_offset}, {info.Log()})");
                         })
                     .Verifiable();
             }
@@ -1326,9 +1459,9 @@ namespace DokanNet.Tests
         internal void ExpectWriteFile(string path, byte[] buffer, int bytesWritten, object context = null, bool synchronousIo = true)
         {
             operations
-                .Setup(d => d.WriteFile(path, It.Is<byte[]>(b => b.SequenceEqual(buffer)), out bytesWritten, 0, It.Is<DokanFileInfo>(i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
+                .Setup(d => d.WriteFile(path, It.Is<byte[]>(b => b.SequenceEqual(buffer)), out bytesWritten, 0, It.Is<IDokanFileInfo>(i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, byte[] _buffer, int _bytesWritten, long offset, DokanFileInfo info)
+                .Callback((string fileName, byte[] _buffer, int _bytesWritten, long offset, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.WriteFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_buffer.Length}], out {_bytesWritten}, {offset}, {info.Log()})"))
                 .Verifiable();
         }
@@ -1342,10 +1475,10 @@ namespace DokanNet.Tests
         internal void ExpectWriteFileWithDelay(string path, byte[] buffer, int bytesWritten, TimeSpan delay)
         {
             operations
-                .Setup(d => d.WriteFile(path, It.Is<byte[]>(b => IsSequenceEqual(b, buffer) /*b.SequenceEqual(buffer)*/), out bytesWritten, 0, It.Is<DokanFileInfo>(i => !i.IsDirectory && i.SynchronousIo)))
+                .Setup(d => d.WriteFile(path, It.Is<byte[]>(b => IsSequenceEqual(b, buffer) /*b.SequenceEqual(buffer)*/), out bytesWritten, 0, It.Is<IDokanFileInfo>(i => !i.IsDirectory && i.SynchronousIo)))
                 .Callback(() => Thread.Sleep(delay))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, byte[] _buffer, int _bytesWritten, long offset, DokanFileInfo info)
+                .Callback((string fileName, byte[] _buffer, int _bytesWritten, long offset, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.WriteFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_buffer.Length}], out {_bytesWritten}, {offset}, {info.Log()})"))
                 .Verifiable();
         }
@@ -1360,9 +1493,9 @@ namespace DokanNet.Tests
                 var chunk = buffer.Skip(offset).Take(bytesWritten);
                 operations
                     .Setup(d => d.WriteFile(path, It.Is<byte[]>(b => IsSequenceEqual(b, chunk) /*b.SequenceEqual(chunk)*/), out bytesWritten, offsets[index],
-                                It.Is<DokanFileInfo>(i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
+                                It.Is<IDokanFileInfo>(i => i.Context == context && !i.IsDirectory && i.SynchronousIo == synchronousIo)))
                     .Returns(DokanResult.Success)
-                    .Callback((string fileName, byte[] _buffer, int _bytesWritten, long _offset, DokanFileInfo info)
+                    .Callback((string fileName, byte[] _buffer, int _bytesWritten, long _offset, IDokanFileInfo info)
                         => Trace($"{nameof(IDokanOperations.WriteFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_buffer.Length}], out {_bytesWritten}, {_offset}, {info.Log()})"))
                     .Verifiable();
             }
@@ -1371,9 +1504,9 @@ namespace DokanNet.Tests
         internal void ExpectDeleteFile(string path)
         {
             operations
-                .Setup(d => d.DeleteFile(path, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.DeleteFile(path, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DokanFileInfo info)
+                .Callback((string fileName, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.DeleteFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {info.Log()})"))
                 .Verifiable();
         }
@@ -1381,9 +1514,9 @@ namespace DokanNet.Tests
         internal void ExpectMoveFile(string path, string destinationPath, bool replace)
         {
             operations
-                .Setup(d => d.MoveFile(path, destinationPath, replace, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.MoveFile(path, destinationPath, replace, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string oldName, string newName, bool _replace, DokanFileInfo info)
+                .Callback((string oldName, string newName, bool _replace, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.MoveFile)}[{Interlocked.Add(ref pendingFiles, 2)}] (\"{oldName}\", \"{newName}\", {_replace}, {info.Log()})"))
                 .Verifiable();
 
@@ -1393,9 +1526,9 @@ namespace DokanNet.Tests
         internal void ExpectMoveFileToFail(string path, string destinationPath, bool replace, NtStatus result)
         {
             operations
-                .Setup(d => d.MoveFile(path, destinationPath, replace, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.MoveFile(path, destinationPath, replace, It.IsAny<IDokanFileInfo>()))
                 .Returns(result)
-                .Callback((string oldName, string newName, bool _replace, DokanFileInfo info)
+                .Callback((string oldName, string newName, bool _replace, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.MoveFile)}[{Interlocked.Add(ref pendingFiles, 2)}] **{result}** (\"{oldName}\", \"{newName}\", {_replace}, {info.Log()})"))
                 .Verifiable();
 
@@ -1407,9 +1540,9 @@ namespace DokanNet.Tests
         internal void ExpectSetAllocationSize(string path, long length)
         {
             operations
-                .Setup(d => d.SetAllocationSize(path, length, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.SetAllocationSize(path, length, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long _length, DokanFileInfo info)
+                .Callback((string fileName, long _length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetAllocationSize)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {_length}, {info.Log()})"))
                 .Verifiable();
         }
@@ -1417,9 +1550,9 @@ namespace DokanNet.Tests
         internal void ExpectSetEndOfFile(string path, long length)
         {
             operations
-                .Setup(d => d.SetEndOfFile(path, length, It.Is<DokanFileInfo>(i => !i.IsDirectory)))
+                .Setup(d => d.SetEndOfFile(path, length, It.Is<IDokanFileInfo>(i => !i.IsDirectory)))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, long _length, DokanFileInfo info)
+                .Callback((string fileName, long _length, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetEndOfFile)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {_length}, {info.Log()})"))
                 .Verifiable();
         }
@@ -1427,18 +1560,18 @@ namespace DokanNet.Tests
         internal void ExpectSetFileAttributes(string path, FileAttributes attributes)
         {
             operations
-                .Setup(d => d.SetFileAttributes(path, attributes, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.SetFileAttributes(path, attributes, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileAttributes _attributes, DokanFileInfo info)
+                .Callback((string fileName, FileAttributes _attributes, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetFileAttributes)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", [{_attributes}], {info.Log()})"));
         }
 
         internal void ExpectSetFileTime(string path)
         {
             operations
-                .Setup(d => d.SetFileTime(path, It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.SetFileTime(path, It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, DokanFileInfo info)
+                .Callback((string fileName, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetFileTime)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {creationTime}, {lastAccessTime}, {lastWriteTime}, {info.Log()})"))
                 .Verifiable();
         }
@@ -1446,21 +1579,21 @@ namespace DokanNet.Tests
         internal void ExpectGetFileSecurity(string path, FileSystemSecurity security, AccessControlSections access = AccessControlSections.Access | AccessControlSections.Owner | AccessControlSections.Group)
         {
             operations
-                .Setup(d => d.GetFileSecurity(path, out security, access, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.GetFileSecurity(path, out security, access, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileSystemSecurity _security, AccessControlSections _access, DokanFileInfo info)
+                .Callback((string fileName, FileSystemSecurity _security, AccessControlSections _access, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.GetFileSecurity)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out {_security.AsString()}, {_access}, {info.Log()})"))
                 .Verifiable();
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "security", Justification = "Reserved for future use")]
-        internal void ExpectSetFileSecurity(string path, FileSystemSecurity security)
+        internal void ExpectSetFileSecurity(string path, FileSystemSecurity _2)
         {
             operations
-                //.Setup(d => d.SetFileSecurity(path, security, AccessControlSections.Access, It.IsAny<DokanFileInfo>()))
-                .Setup(d => d.SetFileSecurity(path, It.IsAny<FileSystemSecurity>(), AccessControlSections.Access, It.IsAny<DokanFileInfo>()))
+                //.Setup(d => d.SetFileSecurity(path, security, AccessControlSections.Access, It.IsAny<IDokanFileInfo>()))
+                .Setup(d => d.SetFileSecurity(path, It.IsAny<FileSystemSecurity>(), AccessControlSections.Access, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.Success)
-                .Callback((string fileName, FileSystemSecurity _security, AccessControlSections access, DokanFileInfo info)
+                .Callback((string fileName, FileSystemSecurity _security, AccessControlSections access, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.SetFileSecurity)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", {_security.AsString()}, {access}, {info.Log()})"))
                 .Verifiable();
         }
@@ -1469,9 +1602,9 @@ namespace DokanNet.Tests
         {
             long streamSize = streamNames.Count;
             operations
-                .Setup(d => d.FindStreams(path, out streamNames, It.IsAny<DokanFileInfo>()))
+                .Setup(d => d.FindStreams(path, out streamNames, It.IsAny<IDokanFileInfo>()))
                 .Returns(DokanResult.NotImplemented)
-                .Callback((string fileName, IList<FileInformation> _streamNames, DokanFileInfo info)
+                .Callback((string fileName, IList<FileInformation> _streamNames, IDokanFileInfo info)
                     => Trace($"{nameof(IDokanOperations.FindStreams)}[{Interlocked.Read(ref pendingFiles)}] (\"{fileName}\", out [{_streamNames.Count}], {info.Log()})"))
                 .Verifiable();
         }
@@ -1507,7 +1640,7 @@ namespace DokanNet.Tests
 
             int bytesRead;
             operations.Verify();
-            operations.Verify(d => d.ReadFile(fileName, It.IsAny<byte[]>(), out bytesRead, It.IsAny<long>(), It.IsAny<DokanFileInfo>()), Times.Exactly(count));
+            operations.Verify(d => d.ReadFile(fileName, It.IsAny<byte[]>(), out bytesRead, It.IsAny<long>(), It.IsAny<IDokanFileInfo>()), Times.Exactly(count));
         }
 
         internal void VerifyContextWriteInvocations(string fileName, int count)
@@ -1516,7 +1649,7 @@ namespace DokanNet.Tests
 
             int bytesRead;
             operations.Verify();
-            operations.Verify(d => d.WriteFile(fileName, It.IsAny<byte[]>(), out bytesRead, It.IsAny<long>(), It.IsAny<DokanFileInfo>()), Times.Exactly(count));
+            operations.Verify(d => d.WriteFile(fileName, It.IsAny<byte[]>(), out bytesRead, It.IsAny<long>(), It.IsAny<IDokanFileInfo>()), Times.Exactly(count));
         }
     }
 }

--- a/DokanNet.Tests/LogExtensions.cs
+++ b/DokanNet.Tests/LogExtensions.cs
@@ -2,7 +2,7 @@
 {
     internal static class LogExtensions
     {
-        public static string Log(this DokanFileInfo info)
+        public static string Log(this IDokanFileInfo info)
             => $"{nameof(DokanFileInfo)} {{{info.Context ?? "<null>"}, {(info.DeleteOnClose ? nameof(info.DeleteOnClose) : "")}, {(info.IsDirectory ? nameof(info.IsDirectory) : "")}, {(info.NoCache ? nameof(info.NoCache) : "")}, {(info.PagingIo ? nameof(info.PagingIo) : "")}, {info.ProcessId}, {(info.SynchronousIo ? nameof(info.SynchronousIo) : "")}, {(info.WriteToEndOfFile ? nameof(info.WriteToEndOfFile) : "")}}}";
 
         public static string Log(this FileInformation fileInfo)

--- a/DokanNet/DokanFileInfo.cs
+++ b/DokanNet/DokanFileInfo.cs
@@ -17,7 +17,7 @@ namespace DokanNet
     /// This is the same structure as <c>_DOKAN_FILE_INFO</c> (dokan.h) in the C++ version of Dokan.
     /// </remarks>
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
-    public sealed class DokanFileInfo
+    public sealed class DokanFileInfo : IDokanFileInfo
     {
         private ulong _context;
 

--- a/DokanNet/IDokanFileInfo.cs
+++ b/DokanNet/IDokanFileInfo.cs
@@ -1,0 +1,68 @@
+﻿using System.Security.Principal;
+
+namespace DokanNet
+{
+    public interface IDokanFileInfo
+    {
+        /// <summary>
+        /// Gets or sets context that can be used to carry information between operation.
+        /// The Context can carry whatever type like <c><see cref="System.IO.FileStream"/></c>, <c>struct</c>, <c>int</c>,
+        /// or internal reference that will help the implementation understand the request context of the event.
+        /// </summary>
+        object Context { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the file has to be delete
+        /// during the <see cref="IDokanOperations.Cleanup"/> event.
+        /// </summary>
+        bool DeleteOnClose { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether it requesting a directory
+        /// file. Must be set in <see cref="IDokanOperations.CreateFile"/> if
+        /// the file appear to be a folder.
+        /// </summary>
+        bool IsDirectory { get; set; }
+
+        /// <summary>
+        /// Read or write directly from data source without cache.
+        /// </summary>
+        bool NoCache { get; }
+
+        /// <summary>
+        /// Read or write is paging IO.
+        /// </summary>
+        bool PagingIo { get; }
+
+        /// <summary>
+        /// Process id for the thread that originally requested a given I/O
+        /// operation.
+        /// </summary>
+        int ProcessId { get; }
+
+        /// <summary>
+        /// Read or write is synchronous IO.
+        /// </summary>
+        bool SynchronousIo { get; }
+
+        /// <summary>
+        /// If <c>true</c>, write to the current end of file instead 
+        /// of using the <c>Offset</c> parameter.
+        /// </summary>
+        bool WriteToEndOfFile { get; }
+
+        /// <summary>
+        /// This method needs to be called in <see cref="IDokanOperations.CreateFile"/>.
+        /// </summary>
+        /// <returns>An <c><see cref="WindowsIdentity"/></c> with the access token, 
+        /// -or- <c>null</c> if the operation was not successful.</returns>
+        WindowsIdentity GetRequestor();
+
+        /// <summary>
+        /// Extends the time out of the current IO operation in driver.
+        /// </summary>
+        /// <param name="milliseconds">Number of milliseconds to extend with.</param>
+        /// <returns>If the operation was successful.</returns>
+        bool TryResetTimeout(int milliseconds);
+    }
+}

--- a/DokanNet/IDokanOperations.cs
+++ b/DokanNet/IDokanOperations.cs
@@ -30,11 +30,11 @@ namespace DokanNet
         /// 
         /// If the file is a directory, CreateFile is also called.
         /// In this case, CreateFile should return <see cref="NtStatus.Success"/> when that directory
-        /// can be opened and <see cref="DokanFileInfo.IsDirectory"/> has to be set to <c>true</c>.
-        /// On the other hand, if <see cref="DokanFileInfo.IsDirectory"/> is set to <c>true</c>
+        /// can be opened and <see cref="IDokanFileInfo.IsDirectory"/> must be set to <c>true</c>.
+        /// On the other hand, if <see cref="IDokanFileInfo.IsDirectory"/> is set to <c>true</c>
         /// but the path target a file, you need to return <see cref="DokanResult.NotADirectory"/>
         /// 
-        /// <see cref="DokanFileInfo.Context"/> can be used to store data (like <c><see cref="FileStream"/></c>)
+        /// <see cref="IDokanFileInfo.Context"/> can be used to store data (like <c><see cref="FileStream"/></c>)
         /// that can be retrieved in all other request related to the context.
         /// </summary>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
@@ -46,7 +46,7 @@ namespace DokanNet
         /// <param name="mode">Specifies how the operating system should open a file. See <a href="https://msdn.microsoft.com/en-us/library/system.io.filemode(v=vs.110).aspx">FileMode Enumeration (MSDN)</a>.</param>
         /// <param name="options">Represents advanced options for creating a FileStream object. See <a href="https://msdn.microsoft.com/en-us/library/system.io.fileoptions(v=vs.110).aspx">FileOptions Enumeration (MSDN)</a>.</param>
         /// <param name="attributes">Provides attributes for files and directories. See <a href="https://msdn.microsoft.com/en-us/library/system.io.fileattributes(v=vs.110).aspx">FileAttributes Enumeration (MSDN></a>.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// \see See <a href="https://msdn.microsoft.com/en-us/library/windows/hardware/ff566424(v=vs.85).aspx">ZwCreateFile (MSDN)</a> for more information about the parameters of this callback.
         NtStatus CreateFile(
@@ -56,7 +56,7 @@ namespace DokanNet
             FileMode mode,
             FileOptions options,
             FileAttributes attributes,
-            DokanFileInfo info);
+            IDokanFileInfo info);
 
         /// <summary>
         /// Receipt of this request indicates that the last handle for a file object that is associated 
@@ -66,15 +66,15 @@ namespace DokanNet
         /// Cleanup is requested before <see cref="CloseFile"/> is called.
         /// </summary>
         /// <remarks>
-        /// When <see cref="DokanFileInfo.DeleteOnClose"/> is <c>true</c>, you must delete the file in Cleanup.
+        /// When <see cref="IDokanFileInfo.DeleteOnClose"/> is <c>true</c>, you must delete the file in Cleanup.
         /// Refer to <see cref="DeleteFile"/> and <see cref="DeleteDirectory"/> for explanation.
         /// </remarks>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <seealso cref="DeleteFile"/>
         /// <seealso cref="DeleteDirectory"/>
         /// <seealso cref="CloseFile"/>
-        void Cleanup(string fileName, DokanFileInfo info);
+        void Cleanup(string fileName, IDokanFileInfo info);
 
         /// <summary>
         /// CloseFile is called at the end of the life of the context.
@@ -85,12 +85,12 @@ namespace DokanNet
         /// 
         /// CloseFile is requested after <see cref="Cleanup"/> is called.
         /// 
-        /// Remainings in <see cref="DokanFileInfo.Context"/> has to be cleared before return.
+        /// Remainings in <see cref="IDokanFileInfo.Context"/> has to be cleared before return.
         /// </summary>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <seealso cref="Cleanup"/>
-        void CloseFile(string fileName, DokanFileInfo info);
+        void CloseFile(string fileName, IDokanFileInfo info);
 
         /// <summary>
         /// ReadFile callback on the file previously opened in <see cref="CreateFile"/>.
@@ -102,10 +102,10 @@ namespace DokanNet
         /// The buffer size depend of the read size requested by the kernel.</param>
         /// <param name="bytesRead">Total number of bytes that has been read.</param>
         /// <param name="offset">Offset from where the read has to be proceed.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="WriteFile"/>
-        NtStatus ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, DokanFileInfo info);
+        NtStatus ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, IDokanFileInfo info);
 
         /// <summary>
         /// WriteFile callback on the file previously opened in <see cref="CreateFile"/>
@@ -116,27 +116,27 @@ namespace DokanNet
         /// <param name="buffer">Data that has to be written.</param>
         /// <param name="bytesWritten">Total number of bytes that has been write.</param>
         /// <param name="offset">Offset from where the write has to be proceed.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="ReadFile"/>
-        NtStatus WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info);
+        NtStatus WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, IDokanFileInfo info);
 
         /// <summary>
         /// Clears buffers for this context and causes any buffered data to be written to the file.
         /// </summary>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
-        NtStatus FlushFileBuffers(string fileName, DokanFileInfo info);
+        NtStatus FlushFileBuffers(string fileName, IDokanFileInfo info);
 
         /// <summary>
         /// Get specific informations on a file.
         /// </summary>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="fileInfo"><see cref="FileInformation"/> struct to fill</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
-        NtStatus GetFileInformation(string fileName, out FileInformation fileInfo, DokanFileInfo info);
+        NtStatus GetFileInformation(string fileName, out FileInformation fileInfo, IDokanFileInfo info);
 
         /// <summary>
         /// List all files in the path requested
@@ -146,10 +146,10 @@ namespace DokanNet
         /// </summary>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="files">A list of <see cref="FileInformation"/> to return.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="FindFilesWithPattern"/>
-        NtStatus FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info);
+        NtStatus FindFiles(string fileName, out IList<FileInformation> files, IDokanFileInfo info);
 
         /// <summary>
         /// Same as <see cref="FindFiles"/> but with a search pattern to filter the result.
@@ -157,14 +157,14 @@ namespace DokanNet
         /// <param name="fileName">Path requested by the Kernel on the FileSystem.</param>
         /// <param name="searchPattern">Search pattern</param>
         /// <param name="files">A list of <see cref="FileInformation"/> to return.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="FindFiles"/>
         NtStatus FindFilesWithPattern(
             string fileName,
             string searchPattern,
             out IList<FileInformation> files,
-            DokanFileInfo info);
+            IDokanFileInfo info);
 
         /// <summary>
         /// Set file attributes on a specific file.
@@ -172,9 +172,9 @@ namespace DokanNet
         /// <remarks>SetFileAttributes and <see cref="SetFileTime"/> are called only if both of them are implemented.</remarks>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="attributes"><see cref="FileAttributes"/> to set on file</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
-        NtStatus SetFileAttributes(string fileName, FileAttributes attributes, DokanFileInfo info);
+        NtStatus SetFileAttributes(string fileName, FileAttributes attributes, IDokanFileInfo info);
 
         /// <summary>
         /// Set file times on a specific file.
@@ -185,14 +185,14 @@ namespace DokanNet
         /// <param name="creationTime"><see cref="DateTime"/> when the file was created.</param>
         /// <param name="lastAccessTime"><see cref="DateTime"/> when the file was last accessed.</param>
         /// <param name="lastWriteTime"><see cref="DateTime"/> when the file was last written to.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         NtStatus SetFileTime(
             string fileName,
             DateTime? creationTime,
             DateTime? lastAccessTime,
             DateTime? lastWriteTime,
-            DokanFileInfo info);
+            IDokanFileInfo info);
 
         /// <summary>
         /// Check if it is possible to delete a file.
@@ -203,19 +203,19 @@ namespace DokanNet
         /// and return <see cref="NtStatus.Success"/> (when you can delete it) or appropriate error
         /// codes such as <see cref="NtStatus.AccessDenied"/>, <see cref="NtStatus.ObjectNameNotFound"/>.
         ///
-        /// DeleteFile will also be called with <see cref="DokanFileInfo.DeleteOnClose"/> set to <c>false</c>
+        /// DeleteFile will also be called with <see cref="IDokanFileInfo.DeleteOnClose"/> set to <c>false</c>
         /// to notify the driver when the file is no longer requested to be deleted.
         /// 
         /// When you return <see cref="NtStatus.Success"/>, you get a <see cref="Cleanup"/> call afterwards with
-        /// <see cref="DokanFileInfo.DeleteOnClose"/> set to <c>true</c> and only then you have to actually
+        /// <see cref="IDokanFileInfo.DeleteOnClose"/> set to <c>true</c> and only then you have to actually
         /// delete the file being closed.
         /// </remarks>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns>Return <see cref="DokanResult.Success"/> if file can be delete or <see cref="NtStatus"/> appropriate.</returns>
         /// <seealso cref="DeleteDirectory"/>
         /// <seealso cref="Cleanup"/>
-        NtStatus DeleteFile(string fileName, DokanFileInfo info);
+        NtStatus DeleteFile(string fileName, IDokanFileInfo info);
 
         /// <summary>
         /// Check if it is possible to delete a directory.
@@ -227,19 +227,19 @@ namespace DokanNet
         /// codes such as <see cref="NtStatus.AccessDenied"/>, <see cref="NtStatus.ObjectPathNotFound"/>,
         /// <see cref="NtStatus.ObjectNameNotFound"/>.
         ///
-        /// DeleteFile will also be called with <see cref="DokanFileInfo.DeleteOnClose"/> set to <c>false</c>
+        /// DeleteFile will also be called with <see cref="IDokanFileInfo.DeleteOnClose"/> set to <c>false</c>
         /// to notify the driver when the file is no longer requested to be deleted.
         ///
         /// When you return <see cref="NtStatus.Success"/>, you get a <see cref="Cleanup"/> call afterwards with
-        /// <see cref="DokanFileInfo.DeleteOnClose"/> set to <c>true</c> and only then you have to actually
+        /// <see cref="IDokanFileInfo.DeleteOnClose"/> set to <c>true</c> and only then you have to actually
         /// delete the file being closed.
         /// </remarks>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns>Return <see cref="DokanResult.Success"/> if file can be delete or <see cref="NtStatus"/> appropriate.</returns>
         /// <seealso cref="DeleteFile"/>
         /// <seealso cref="Cleanup"/>
-        NtStatus DeleteDirectory(string fileName, DokanFileInfo info);
+        NtStatus DeleteDirectory(string fileName, IDokanFileInfo info);
 
         /// <summary>
         /// Move a file or directory to a new location.
@@ -247,27 +247,27 @@ namespace DokanNet
         /// <param name="oldName">Path to the file to move.</param>
         /// <param name="newName">Path to the new location for the file.</param>
         /// <param name="replace">If the file should be replaced if it already exist a file with path <paramref name="newName"/>.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
-        NtStatus MoveFile(string oldName, string newName, bool replace, DokanFileInfo info);
+        NtStatus MoveFile(string oldName, string newName, bool replace, IDokanFileInfo info);
 
         /// <summary>
         /// SetEndOfFile is used to truncate or extend a file (physical file size).
         /// </summary>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="length">File length to set</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
-        NtStatus SetEndOfFile(string fileName, long length, DokanFileInfo info);
+        NtStatus SetEndOfFile(string fileName, long length, IDokanFileInfo info);
 
         /// <summary>
         /// SetAllocationSize is used to truncate or extend a file.
         /// </summary>
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="length">File length to set</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
-        NtStatus SetAllocationSize(string fileName, long length, DokanFileInfo info);
+        NtStatus SetAllocationSize(string fileName, long length, IDokanFileInfo info);
 
         /// <summary>
         /// Lock file at a specific offset and data length.
@@ -276,10 +276,10 @@ namespace DokanNet
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="offset">Offset from where the lock has to be proceed.</param>
         /// <param name="length">Data length to lock.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="UnlockFile"/>
-        NtStatus LockFile(string fileName, long offset, long length, DokanFileInfo info);
+        NtStatus LockFile(string fileName, long offset, long length, IDokanFileInfo info);
 
         /// <summary>
         /// Unlock file at a specific offset and data length.
@@ -288,23 +288,23 @@ namespace DokanNet
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="offset">Offset from where the unlock has to be proceed.</param>
         /// <param name="length">Data length to lock.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="LockFile"/>
-        NtStatus UnlockFile(string fileName, long offset, long length, DokanFileInfo info);
+        NtStatus UnlockFile(string fileName, long offset, long length, IDokanFileInfo info);
 
         /// <summary>
         /// Retrieves information about the amount of space that is available on a disk volume, which is the total amount of space, 
         /// the total amount of free space, and the total amount of free space available to the user that is associated with the calling thread.
         /// </summary>
         /// <remarks>
-        /// Neither GetDiskFreeSpace nor <see cref="GetVolumeInformation"/> save the <see cref="DokanFileInfo.Context"/>.
+        /// Neither GetDiskFreeSpace nor <see cref="GetVolumeInformation"/> save the <see cref="IDokanFileInfo.Context"/>.
         /// Before these methods are called, <see cref="CreateFile"/> may not be called. (ditto <see cref="CloseFile"/> and <see cref="Cleanup"/>).
         /// </remarks>
         /// <param name="freeBytesAvailable">Amount of available space.</param>
         /// <param name="totalNumberOfBytes">Total size of storage space.</param>
         /// <param name="totalNumberOfFreeBytes">Amount of free space.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa364937(v=vs.85).aspx"> GetDiskFreeSpaceEx function (MSDN)</a>
         /// <seealso cref="GetVolumeInformation"/>
@@ -312,13 +312,13 @@ namespace DokanNet
             out long freeBytesAvailable,
             out long totalNumberOfBytes,
             out long totalNumberOfFreeBytes,
-            DokanFileInfo info);
+            IDokanFileInfo info);
 
         /// <summary>
         /// Retrieves information about the file system and volume associated with the specified root directory.
         /// </summary>
         /// <remarks>
-        /// Neither GetVolumeInformation nor <see cref="GetDiskFreeSpace"/> save the <see cref="DokanFileInfo.Context"/>.
+        /// Neither GetVolumeInformation nor <see cref="GetDiskFreeSpace"/> save the <see cref="IDokanFileInfo.Context"/>.
         /// Before these methods are called, <see cref="CreateFile"/> may not be called. (ditto <see cref="CloseFile"/> and <see cref="Cleanup"/>).
         /// 
         /// <see cref="FileSystemFeatures.ReadOnlyVolume"/> is automatically added to the <paramref name="features"/> if <see cref="DokanOptions.WriteProtection"/> was
@@ -337,7 +337,7 @@ namespace DokanNet
         /// <param name="features"><see cref="FileSystemFeatures"/> with features enabled on the volume.</param>
         /// <param name="fileSystemName">The name of the specified volume.</param>
         /// <param name="maximumComponentLength">File name component that the specified file system supports.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa364993(v=vs.85).aspx"> GetVolumeInformation function (MSDN)</a>
         NtStatus GetVolumeInformation(
@@ -345,7 +345,7 @@ namespace DokanNet
             out FileSystemFeatures features,
             out string fileSystemName,
             out uint maximumComponentLength,
-            DokanFileInfo info);
+            IDokanFileInfo info);
 
         /// <summary>
         /// Get specified information about the security of a file or directory. 
@@ -359,7 +359,7 @@ namespace DokanNet
         /// <param name="fileName">File or directory name.</param>
         /// <param name="security">A <see cref="FileSystemSecurity"/> with security information to return.</param>
         /// <param name="sections">A <see cref="AccessControlSections"/> with access sections to return.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="SetFileSecurity"/>
         /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa446639(v=vs.85).aspx">GetFileSecurity function (MSDN)</a>
@@ -367,7 +367,7 @@ namespace DokanNet
             string fileName,
             out FileSystemSecurity security,
             AccessControlSections sections,
-            DokanFileInfo info);
+            IDokanFileInfo info);
 
         /// <summary>
         /// Sets the security of a file or directory object.
@@ -377,7 +377,7 @@ namespace DokanNet
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="security">A <see cref="FileSystemSecurity"/> with security information to set.</param>
         /// <param name="sections">A <see cref="AccessControlSections"/> with access sections on which.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="GetFileSecurity"/>
         /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa379577(v=vs.85).aspx">SetFileSecurity function (MSDN)</a>
@@ -385,23 +385,23 @@ namespace DokanNet
             string fileName,
             FileSystemSecurity security,
             AccessControlSections sections,
-            DokanFileInfo info);
+            IDokanFileInfo info);
 
         /// <summary>
         /// Is called when %Dokan succeed to mount the volume.
         /// </summary>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <see cref="Unmounted"/>
-        NtStatus Mounted(DokanFileInfo info);
+        NtStatus Mounted(IDokanFileInfo info);
 
         /// <summary>
         /// Is called when %Dokan is unmounting the volume.
         /// </summary>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="Mounted"/>
-        NtStatus Unmounted(DokanFileInfo info);
+        NtStatus Unmounted(IDokanFileInfo info);
 
         /// <summary>
         /// Retrieve all NTFS Streams informations on the file.
@@ -413,11 +413,11 @@ namespace DokanNet
         /// 
         /// <param name="fileName">File path requested by the Kernel on the FileSystem.</param>
         /// <param name="streams">List of <see cref="FileInformation"/> for each streams present on the file.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns>Return <see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa364424(v=vs.85).aspx">FindFirstStreamW function (MSDN)</a>
         /// \see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa365993(v=vs.85).aspx">About KTM (MSDN)</a>
-        NtStatus FindStreams(string fileName, out IList<FileInformation> streams, DokanFileInfo info);
+        NtStatus FindStreams(string fileName, out IList<FileInformation> streams, IDokanFileInfo info);
     }
 }
 

--- a/DokanNet/IDokanOperationsUnsafe.cs
+++ b/DokanNet/IDokanOperationsUnsafe.cs
@@ -25,10 +25,10 @@ namespace DokanNet
         /// The buffer size depends of the read size requested by the kernel.</param>
         /// <param name="bytesRead">Total number of bytes that has been read.</param>
         /// <param name="offset">Offset from where the read has to be proceed.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="WriteFile"/>
-        NtStatus ReadFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesRead, long offset, DokanFileInfo info);
+        NtStatus ReadFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesRead, long offset, IDokanFileInfo info);
 
         /// <summary>
         /// WriteFile callback on the file previously opened in <see cref="CreateFile"/>
@@ -40,9 +40,9 @@ namespace DokanNet
         /// <param name="bufferLength">The size of 'buffer' in bytes.</param>
         /// <param name="bytesWritten">Total number of bytes that has been write.</param>
         /// <param name="offset">Offset from where the write has to be proceed.</param>
-        /// <param name="info">An <see cref="DokanFileInfo"/> with information about the file or directory.</param>
+        /// <param name="info">An <see cref="IDokanFileInfo"/> with information about the file or directory.</param>
         /// <returns><see cref="NtStatus"/> or <see cref="DokanResult"/> appropriate to the request result.</returns>
         /// <seealso cref="ReadFile"/>
-        NtStatus WriteFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesWritten, long offset, DokanFileInfo info);
+        NtStatus WriteFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesWritten, long offset, IDokanFileInfo info);
     }
 }

--- a/DokanNet/MockDokanFileInfo.cs
+++ b/DokanNet/MockDokanFileInfo.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using DokanNet.Native;
+using Microsoft.Win32.SafeHandles;
+using static DokanNet.FormatProviders;
+
+#pragma warning disable 649,169
+
+namespace DokanNet
+{
+    /// <summary>
+    /// Mockable Dokan file information on the current operation.
+    /// </summary>
+    /// <remarks>
+    /// Because <see cref="DokanFileInfo"/> cannot be instantiated in C#, it's very difficult to write
+    /// test harnesses for unit testing.  This class implements the same public interface so it's
+    /// possible to mock it, such that the implementor of IDokanOperations can essentially act like
+    /// the dokany kernel driver and call into that implementation to verify correct behavior.  It
+    /// also has support methods available to cause it (and the Dokan.Net library) to behave in certain
+    /// ways useful for testing all potential returns, both success and failure.
+    /// </remarks>
+    public sealed class MockDokanFileInfo : IDokanFileInfo
+    {
+        public MockDokanFileInfo()
+        {
+        }
+
+        /// <summary>
+        /// A <see cref="DOKAN_OPTIONS"> structure used to help the kernel notification functions work.
+        /// </summary>
+        private DOKAN_OPTIONS _dokanOptions = new DOKAN_OPTIONS();
+
+        /// <summary>
+        /// This must be set to a potentially valid path.  Examples might be @"M:\" or @"C:\JunctionPoint".
+        /// </summary>
+        /// <remarks>The trailing backslash is not optional for drive letters, and must be omitted for paths.</remarks>
+        public string MountPoint
+        {
+            get => _dokanOptions.MountPoint;
+            set => _dokanOptions.MountPoint = value;
+        }
+
+        /// <summary>
+        /// Gets or sets context that can be used to carry information between operation.
+        /// The Context can carry an arbitrary type, like <c><see cref="System.IO.FileStream"/></c>, <c>struct</c>, <c>int</c>,
+        /// or internal reference that will help the implementation understand the request context of the event.
+        /// </summary>
+        public object Context
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Process id for the thread that originally requested a given I/O
+        /// operation.
+        /// </summary>
+        public int ProcessId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a filename references a directory.
+        /// Must be set in <see cref="IDokanOperations.CreateFile"/> if the file is to
+        /// appear to be a folder.
+        /// </summary>
+        public bool IsDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the file has to be deleted
+        /// during the <see cref="IDokanOperations.Cleanup"/> event.
+        /// </summary>
+        public bool DeleteOnClose { get; set; }
+
+        /// <summary>
+        /// Read or write is paging IO.
+        /// </summary>
+        public bool PagingIo { get; set; }
+
+        /// <summary>
+        /// Read or write is synchronous IO.
+        /// </summary>
+        public bool SynchronousIo { get; set; }
+
+        /// <summary>
+        /// Read or write directly from data source without cache.
+        /// </summary>
+        public bool NoCache { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, write to the current end of file instead 
+        /// of using the <c>Offset</c> parameter.
+        /// </summary>
+        public bool WriteToEndOfFile { get; set; }
+
+        /// <summary>
+        /// Set this to null if you want to test against token unavailability.
+        /// </summary>
+        /// <remarks>Initialized to the current process token, which is the only
+        /// token a standard user account can get.</remarks>
+        public WindowsIdentity WhatGetRequestorShouldReturn = WindowsIdentity.GetCurrent();
+
+        /// <summary>
+        /// This method needs to be called in <see cref="IDokanOperations.CreateFile"/> to
+        /// determine what account and what privileges are available to the filesystem client.
+        /// </summary>
+        /// <returns>An <c><see cref="WindowsIdentity"/></c> with the access token, 
+        /// -or- <c>null</c> if the operation was not successful.</returns>
+        /// <remarks>This Mock implementation returns <see cref="WhatGetRequestorShouldReturn"/>.
+        /// </remarks>
+        public WindowsIdentity GetRequestor() => WhatGetRequestorShouldReturn;
+
+        /// <summary>
+        /// Set this to false if you want to test against TryResetTimeout failure
+        /// </summary>
+        public bool WhatTryResetTimeoutShouldReturn { get; set; }
+
+        /// <summary>
+        /// Extends the time out of the current IO operation in driver.
+        /// </summary>
+        /// <param name="milliseconds">Number of milliseconds to extend with.</param>
+        /// <returns>true if the operation was successful.</returns>
+        /// <remarks>This Mock implementation returns <see cref="WhatTryResetTimeoutShouldReturn"/>.
+        /// </remarks>
+        public bool TryResetTimeout(int milliseconds) => WhatTryResetTimeoutShouldReturn;
+
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return
+                DokanFormat(
+                    $"mock: {{{Context}, {DeleteOnClose}, {IsDirectory}, {NoCache}, {PagingIo}, #{ProcessId}, {SynchronousIo}, {WriteToEndOfFile}}}");
+        }
+    }
+}
+
+#pragma warning restore 649, 169

--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -39,7 +39,7 @@ namespace DokanNetMirror
             return path + fileName;
         }
 
-        protected NtStatus Trace(string method, string fileName, DokanFileInfo info, NtStatus result,
+        protected NtStatus Trace(string method, string fileName, IDokanFileInfo info, NtStatus result,
             params object[] parameters)
         {
 #if TRACE
@@ -53,7 +53,7 @@ namespace DokanNetMirror
             return result;
         }
 
-        private NtStatus Trace(string method, string fileName, DokanFileInfo info,
+        private NtStatus Trace(string method, string fileName, IDokanFileInfo info,
             FileAccess access, FileShare share, FileMode mode, FileOptions options, FileAttributes attributes,
             NtStatus result)
         {
@@ -69,7 +69,7 @@ namespace DokanNetMirror
         #region Implementation of IDokanOperations
 
         public NtStatus CreateFile(string fileName, FileAccess access, FileShare share, FileMode mode,
-            FileOptions options, FileAttributes attributes, DokanFileInfo info)
+            FileOptions options, FileAttributes attributes, IDokanFileInfo info)
         {
             var result = DokanResult.Success;
             var filePath = GetPath(fileName);
@@ -234,7 +234,7 @@ namespace DokanNetMirror
                 result);
         }
 
-        public void Cleanup(string fileName, DokanFileInfo info)
+        public void Cleanup(string fileName, IDokanFileInfo info)
         {
 #if TRACE
             if (info.Context != null)
@@ -258,7 +258,7 @@ namespace DokanNetMirror
             Trace(nameof(Cleanup), fileName, info, DokanResult.Success);
         }
 
-        public void CloseFile(string fileName, DokanFileInfo info)
+        public void CloseFile(string fileName, IDokanFileInfo info)
         {
 #if TRACE
             if (info.Context != null)
@@ -271,7 +271,7 @@ namespace DokanNetMirror
             // could recreate cleanup code here but this is not called sometimes
         }
 
-        public NtStatus ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, DokanFileInfo info)
+        public NtStatus ReadFile(string fileName, byte[] buffer, out int bytesRead, long offset, IDokanFileInfo info)
         {
             if (info.Context == null) // memory mapped read
             {
@@ -294,7 +294,7 @@ namespace DokanNetMirror
                 offset.ToString(CultureInfo.InvariantCulture));
         }
 
-        public NtStatus WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, DokanFileInfo info)
+        public NtStatus WriteFile(string fileName, byte[] buffer, out int bytesWritten, long offset, IDokanFileInfo info)
         {
             if (info.Context == null)
             {
@@ -319,7 +319,7 @@ namespace DokanNetMirror
                 offset.ToString(CultureInfo.InvariantCulture));
         }
 
-        public NtStatus FlushFileBuffers(string fileName, DokanFileInfo info)
+        public NtStatus FlushFileBuffers(string fileName, IDokanFileInfo info)
         {
             try
             {
@@ -332,7 +332,7 @@ namespace DokanNetMirror
             }
         }
 
-        public NtStatus GetFileInformation(string fileName, out FileInformation fileInfo, DokanFileInfo info)
+        public NtStatus GetFileInformation(string fileName, out FileInformation fileInfo, IDokanFileInfo info)
         {
             // may be called with info.Context == null, but usually it isn't
             var filePath = GetPath(fileName);
@@ -352,7 +352,7 @@ namespace DokanNetMirror
             return Trace(nameof(GetFileInformation), fileName, info, DokanResult.Success);
         }
 
-        public NtStatus FindFiles(string fileName, out IList<FileInformation> files, DokanFileInfo info)
+        public NtStatus FindFiles(string fileName, out IList<FileInformation> files, IDokanFileInfo info)
         {
             // This function is not called because FindFilesWithPattern is implemented
             // Return DokanResult.NotImplemented in FindFilesWithPattern to make FindFiles called
@@ -361,7 +361,7 @@ namespace DokanNetMirror
             return Trace(nameof(FindFiles), fileName, info, DokanResult.Success);
         }
 
-        public NtStatus SetFileAttributes(string fileName, FileAttributes attributes, DokanFileInfo info)
+        public NtStatus SetFileAttributes(string fileName, FileAttributes attributes, IDokanFileInfo info)
         {
             try
             {
@@ -386,7 +386,7 @@ namespace DokanNetMirror
         }
 
         public NtStatus SetFileTime(string fileName, DateTime? creationTime, DateTime? lastAccessTime,
-            DateTime? lastWriteTime, DokanFileInfo info)
+            DateTime? lastWriteTime, IDokanFileInfo info)
         {
             try
             {
@@ -426,7 +426,7 @@ namespace DokanNetMirror
             }
         }
 
-        public NtStatus DeleteFile(string fileName, DokanFileInfo info)
+        public NtStatus DeleteFile(string fileName, IDokanFileInfo info)
         {
             var filePath = GetPath(fileName);
 
@@ -443,7 +443,7 @@ namespace DokanNetMirror
             // we just check here if we could delete the file - the true deletion is in Cleanup
         }
 
-        public NtStatus DeleteDirectory(string fileName, DokanFileInfo info)
+        public NtStatus DeleteDirectory(string fileName, IDokanFileInfo info)
         {
             return Trace(nameof(DeleteDirectory), fileName, info,
                 Directory.EnumerateFileSystemEntries(GetPath(fileName)).Any()
@@ -452,7 +452,7 @@ namespace DokanNetMirror
             // if dir is not empty it can't be deleted
         }
 
-        public NtStatus MoveFile(string oldName, string newName, bool replace, DokanFileInfo info)
+        public NtStatus MoveFile(string oldName, string newName, bool replace, IDokanFileInfo info)
         {
             var oldpath = GetPath(oldName);
             var newpath = GetPath(newName);
@@ -498,7 +498,7 @@ namespace DokanNetMirror
                 replace.ToString(CultureInfo.InvariantCulture));
         }
 
-        public NtStatus SetEndOfFile(string fileName, long length, DokanFileInfo info)
+        public NtStatus SetEndOfFile(string fileName, long length, IDokanFileInfo info)
         {
             try
             {
@@ -513,7 +513,7 @@ namespace DokanNetMirror
             }
         }
 
-        public NtStatus SetAllocationSize(string fileName, long length, DokanFileInfo info)
+        public NtStatus SetAllocationSize(string fileName, long length, IDokanFileInfo info)
         {
             try
             {
@@ -528,7 +528,7 @@ namespace DokanNetMirror
             }
         }
 
-        public NtStatus LockFile(string fileName, long offset, long length, DokanFileInfo info)
+        public NtStatus LockFile(string fileName, long offset, long length, IDokanFileInfo info)
         {
 #if !NETCOREAPP1_0
             try
@@ -548,7 +548,7 @@ namespace DokanNetMirror
 #endif
         }
 
-        public NtStatus UnlockFile(string fileName, long offset, long length, DokanFileInfo info)
+        public NtStatus UnlockFile(string fileName, long offset, long length, IDokanFileInfo info)
         {
 #if !NETCOREAPP1_0
             try
@@ -568,7 +568,7 @@ namespace DokanNetMirror
 #endif
         }
 
-        public NtStatus GetDiskFreeSpace(out long freeBytesAvailable, out long totalNumberOfBytes, out long totalNumberOfFreeBytes, DokanFileInfo info)
+        public NtStatus GetDiskFreeSpace(out long freeBytesAvailable, out long totalNumberOfBytes, out long totalNumberOfFreeBytes, IDokanFileInfo info)
         {
             var dinfo = DriveInfo.GetDrives().Single(di => string.Equals(di.RootDirectory.Name, Path.GetPathRoot(path + "\\"), StringComparison.OrdinalIgnoreCase));
 
@@ -580,7 +580,7 @@ namespace DokanNetMirror
         }
 
         public NtStatus GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features,
-            out string fileSystemName, out uint maximumComponentLength, DokanFileInfo info)
+            out string fileSystemName, out uint maximumComponentLength, IDokanFileInfo info)
         {
             volumeLabel = "DOKAN";
             fileSystemName = "NTFS";
@@ -595,7 +595,7 @@ namespace DokanNetMirror
         }
 
         public NtStatus GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
 #if !NETCOREAPP1_0
             try
@@ -618,7 +618,7 @@ namespace DokanNetMirror
         }
 
         public NtStatus SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
 #if !NETCOREAPP1_0
             try
@@ -643,18 +643,18 @@ namespace DokanNetMirror
 #endif
         }
 
-        public NtStatus Mounted(DokanFileInfo info)
+        public NtStatus Mounted(IDokanFileInfo info)
         {
             return Trace(nameof(Mounted), null, info, DokanResult.Success);
         }
 
-        public NtStatus Unmounted(DokanFileInfo info)
+        public NtStatus Unmounted(IDokanFileInfo info)
         {
             return Trace(nameof(Unmounted), null, info, DokanResult.Success);
         }
 
         public NtStatus FindStreams(string fileName, IntPtr enumContext, out string streamName, out long streamSize,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             streamName = string.Empty;
             streamSize = 0;
@@ -662,7 +662,7 @@ namespace DokanNetMirror
                 "out " + streamName, "out " + streamSize.ToString());
         }
 
-        public NtStatus FindStreams(string fileName, out IList<FileInformation> streams, DokanFileInfo info)
+        public NtStatus FindStreams(string fileName, out IList<FileInformation> streams, IDokanFileInfo info)
         {
             streams = new FileInformation[0];
             return Trace(nameof(FindStreams), fileName, info, DokanResult.NotImplemented);
@@ -687,7 +687,7 @@ namespace DokanNetMirror
         }
 
         public NtStatus FindFilesWithPattern(string fileName, string searchPattern, out IList<FileInformation> files,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             files = FindFilesHelper(fileName, searchPattern);
 

--- a/sample/DokanNetMirror/UnsafeMirror.cs
+++ b/sample/DokanNetMirror/UnsafeMirror.cs
@@ -22,7 +22,7 @@ namespace DokanNetMirror
         /// <summary>
         /// Read from file using unmanaged buffers.
         /// </summary>
-        public NtStatus ReadFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesRead, long offset, DokanFileInfo info)
+        public NtStatus ReadFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesRead, long offset, IDokanFileInfo info)
         {
             if (info.Context == null) // memory mapped read
             {
@@ -53,7 +53,7 @@ namespace DokanNetMirror
         /// <summary>
         /// Write to file using unmanaged buffers.
         /// </summary>
-        public NtStatus WriteFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesWritten, long offset, DokanFileInfo info)
+        public NtStatus WriteFile(string fileName, IntPtr buffer, uint bufferLength, out int bytesWritten, long offset, IDokanFileInfo info)
         {
             if (info.Context == null)
             {

--- a/sample/RegistryFS/Program.cs
+++ b/sample/RegistryFS/Program.cs
@@ -26,11 +26,11 @@ namespace RegistryFS
             };
         }
 
-        public void Cleanup(string filename, DokanFileInfo info)
+        public void Cleanup(string filename, IDokanFileInfo info)
         {
         }
 
-        public void CloseFile(string filename, DokanFileInfo info)
+        public void CloseFile(string filename, IDokanFileInfo info)
         {
         }
 
@@ -41,19 +41,19 @@ namespace RegistryFS
             FileMode mode,
             FileOptions options,
             FileAttributes attributes,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             if (info.IsDirectory && mode == FileMode.CreateNew)
                 return DokanResult.AccessDenied;
             return DokanResult.Success;
         }
 
-        public NtStatus DeleteDirectory(string filename, DokanFileInfo info)
+        public NtStatus DeleteDirectory(string filename, IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
 
-        public NtStatus DeleteFile(string filename, DokanFileInfo info)
+        public NtStatus DeleteFile(string filename, IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
@@ -80,7 +80,7 @@ namespace RegistryFS
 
         public NtStatus FlushFileBuffers(
             string filename,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
@@ -88,7 +88,7 @@ namespace RegistryFS
         public NtStatus FindFiles(
             string filename,
             out IList<FileInformation> files,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             files = new List<FileInformation>();
             if (filename == "\\")
@@ -143,7 +143,7 @@ namespace RegistryFS
         public NtStatus GetFileInformation(
             string filename,
             out FileInformation fileinfo,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             fileinfo = new FileInformation {FileName = filename};
 
@@ -173,7 +173,7 @@ namespace RegistryFS
             string filename,
             long offset,
             long length,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             return DokanResult.Success;
         }
@@ -182,7 +182,7 @@ namespace RegistryFS
             string filename,
             string newname,
             bool replace,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
@@ -192,18 +192,18 @@ namespace RegistryFS
             byte[] buffer,
             out int readBytes,
             long offset,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             readBytes = 0;
             return DokanResult.Error;
         }
 
-        public NtStatus SetEndOfFile(string filename, long length, DokanFileInfo info)
+        public NtStatus SetEndOfFile(string filename, long length, IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
 
-        public NtStatus SetAllocationSize(string filename, long length, DokanFileInfo info)
+        public NtStatus SetAllocationSize(string filename, long length, IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
@@ -211,7 +211,7 @@ namespace RegistryFS
         public NtStatus SetFileAttributes(
             string filename,
             FileAttributes attr,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
@@ -221,22 +221,22 @@ namespace RegistryFS
             DateTime? ctime,
             DateTime? atime,
             DateTime? mtime,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
 
-        public NtStatus UnlockFile(string filename, long offset, long length, DokanFileInfo info)
+        public NtStatus UnlockFile(string filename, long offset, long length, IDokanFileInfo info)
         {
             return DokanResult.Success;
         }
 
-        public NtStatus Mounted(DokanFileInfo info)
+        public NtStatus Mounted(IDokanFileInfo info)
         {
             return DokanResult.Success;
         }
 
-        public NtStatus Unmounted(DokanFileInfo info)
+        public NtStatus Unmounted(IDokanFileInfo info)
         {
             return DokanResult.Success;
         }
@@ -245,7 +245,7 @@ namespace RegistryFS
             out long freeBytesAvailable,
             out long totalBytes,
             out long totalFreeBytes,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             freeBytesAvailable = 512*1024*1024;
             totalBytes = 1024*1024*1024;
@@ -258,14 +258,14 @@ namespace RegistryFS
             byte[] buffer,
             out int writtenBytes,
             long offset,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             writtenBytes = 0;
             return DokanResult.Error;
         }
 
         public NtStatus GetVolumeInformation(out string volumeLabel, out FileSystemFeatures features,
-            out string fileSystemName, out uint maximumComponentLength, DokanFileInfo info)
+            out string fileSystemName, out uint maximumComponentLength, IDokanFileInfo info)
         {
             volumeLabel = "RFS";
             features = FileSystemFeatures.None;
@@ -275,34 +275,34 @@ namespace RegistryFS
         }
 
         public NtStatus GetFileSecurity(string fileName, out FileSystemSecurity security, AccessControlSections sections,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             security = null;
             return DokanResult.Error;
         }
 
         public NtStatus SetFileSecurity(string fileName, FileSystemSecurity security, AccessControlSections sections,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             return DokanResult.Error;
         }
 
         public NtStatus EnumerateNamedStreams(string fileName, IntPtr enumContext, out string streamName,
-            out long streamSize, DokanFileInfo info)
+            out long streamSize, IDokanFileInfo info)
         {
             streamName = string.Empty;
             streamSize = 0;
             return DokanResult.NotImplemented;
         }
 
-        public NtStatus FindStreams(string fileName, out IList<FileInformation> streams, DokanFileInfo info)
+        public NtStatus FindStreams(string fileName, out IList<FileInformation> streams, IDokanFileInfo info)
         {
             streams = new FileInformation[0];
             return DokanResult.NotImplemented;
         }
 
         public NtStatus FindFilesWithPattern(string fileName, string searchPattern, out IList<FileInformation> files,
-            DokanFileInfo info)
+            IDokanFileInfo info)
         {
             files = new FileInformation[0];
             return DokanResult.NotImplemented;


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE.**

All implementations of `IDokanOperations` will need to change their final
parameters to accept `IDokanFileInfo` instead of bare `DokanFileInfo`.

New class: `MockDokanFileInfo` This is accepted by implementations of
`IDokanOperations` and `IDokanOperationsUnsafe` as their final
parameters.  You can set all of the values of the public
interfaces of `IDokanFileInfo` (which itself was extracted from the
publicly accessible fields of `DokanFileInfo`), and specify the
mock behavior of both `.TryResetTimeout()` and `.GetRequestor()`.

To use this, your mock code needs to behave as though it is
Dokan, calling into your `IDokanOperations` implementation with
various parameters and testing the expected behaviors and return
values.