### PR TITLE
Add reference implementation for DokanNotify* to mirror-sample

### DIFF
--- a/DokanNet/DokanOptions.cs
+++ b/DokanNet/DokanOptions.cs
@@ -40,6 +40,13 @@ namespace DokanNet
         CurrentSession = 128,
 
         /// <summary>Enable Lockfile/Unlockfile operations.</summary>
-        UserModeLock = 256
+        UserModeLock = 256,
+
+        /// <summary>
+        /// Whether DokanNotifyXXX functions should be enabled, which requires this
+        /// library to maintain a special handle while the file system is mounted.
+        /// Without this flag, the functions always return FALSE if invoked.
+        /// </summary>
+        EnableNotificationAPI = 512,
     }
 }

--- a/sample/DokanNetMirror/Notify.cs
+++ b/sample/DokanNetMirror/Notify.cs
@@ -1,0 +1,109 @@
+﻿using System.IO;
+using DokanNet;
+
+namespace DokanNetMirror
+{
+    internal static class Notify
+    {
+        private static string sourcePath;
+        private static string targetPath;
+        private static FileSystemWatcher commonFsWatcher;
+        private static FileSystemWatcher fileFsWatcher;
+        private static FileSystemWatcher dirFsWatcher;
+
+        public static void Start(string mirrorPath, string mountPath)
+        {
+            sourcePath = mirrorPath;
+            targetPath = mountPath;
+
+            commonFsWatcher = new FileSystemWatcher(mirrorPath)
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.Attributes |
+                    NotifyFilters.CreationTime |
+                    NotifyFilters.DirectoryName |
+                    NotifyFilters.FileName |
+                    NotifyFilters.LastAccess |
+                    NotifyFilters.LastWrite |
+                    NotifyFilters.Security |
+                    NotifyFilters.Size
+            };
+
+            commonFsWatcher.Changed += OnCommonFileSystemWatcherChanged;
+            commonFsWatcher.Created += OnCommonFileSystemWatcherCreated;
+            commonFsWatcher.Renamed += OnCommonFileSystemWatcherRenamed;
+
+            commonFsWatcher.EnableRaisingEvents = true;
+
+            fileFsWatcher = new FileSystemWatcher(mirrorPath)
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.FileName
+            };
+
+            fileFsWatcher.Deleted += OnCommonFileSystemWatcherFileDeleted;
+
+            fileFsWatcher.EnableRaisingEvents = true;
+
+            dirFsWatcher = new FileSystemWatcher(mirrorPath)
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.DirectoryName
+            };
+
+            dirFsWatcher.Deleted += OnCommonFileSystemWatcherDirectoryDeleted;
+
+            dirFsWatcher.EnableRaisingEvents = true;
+        }
+
+        private static string AlterPathToMountPath(string path)
+        {
+            var relativeMirrorPath = path.Substring(sourcePath.Length).TrimStart('\\');
+
+            return Path.Combine(targetPath, relativeMirrorPath);
+        }
+
+        private static void OnCommonFileSystemWatcherFileDeleted(object sender, FileSystemEventArgs e)
+        {
+            var fullPath = AlterPathToMountPath(e.FullPath);
+
+            Dokan.DokanNotifyDelete(fullPath, false);
+        }
+
+        private static void OnCommonFileSystemWatcherDirectoryDeleted(object sender, FileSystemEventArgs e)
+        {
+            var fullPath = AlterPathToMountPath(e.FullPath);
+
+            Dokan.DokanNotifyDelete(fullPath, true);
+        }
+
+        private static void OnCommonFileSystemWatcherChanged(object sender, FileSystemEventArgs e)
+        {
+            var fullPath = AlterPathToMountPath(e.FullPath);
+
+            Dokan.DokanNotifyUpdate(fullPath);
+        }
+
+        private static void OnCommonFileSystemWatcherCreated(object sender, FileSystemEventArgs e)
+        {
+            var fullPath = AlterPathToMountPath(e.FullPath);
+            var isDirectory = Directory.Exists(fullPath);
+
+            Dokan.DokanNotifyCreate(fullPath, isDirectory);
+        }
+
+        private static void OnCommonFileSystemWatcherRenamed(object sender, RenamedEventArgs e)
+        {
+            var oldFullPath = AlterPathToMountPath(e.OldFullPath);
+            var oldDirectoryName = Path.GetDirectoryName(e.OldFullPath);
+
+            var fullPath = AlterPathToMountPath(e.FullPath);
+            var directoryName = Path.GetDirectoryName(e.FullPath);
+
+            var isDirectory = Directory.Exists(e.FullPath);
+            var isInSameDirectory = oldDirectoryName.Equals(directoryName);
+
+            Dokan.DokanNotifyRename(oldFullPath, fullPath, isDirectory, isInSameDirectory);
+        }
+    }
+}

--- a/sample/DokanNetMirror/Program.cs
+++ b/sample/DokanNetMirror/Program.cs
@@ -28,11 +28,13 @@ namespace DokanNetMirror
 
                 var unsafeReadWrite = arguments.ContainsKey(UseUnsafeKey);
 
+                Notify.Start(mirrorPath, mountPath);
+
                 Console.WriteLine($"Using unsafe methods: {unsafeReadWrite}");
                 var mirror = unsafeReadWrite 
                     ? new UnsafeMirror(mirrorPath) 
                     : new Mirror(mirrorPath);
-                mirror.Mount(mountPath, DokanOptions.DebugMode, 5);
+                mirror.Mount(mountPath, DokanOptions.DebugMode | DokanOptions.EnableNotificationAPI, 5);
 
                 Console.WriteLine(@"Success");
             }


### PR DESCRIPTION
These changes add a reference-implementation for the file-change notifications API added with Dokan 1.3.0 to the mirror-sample.

Further, I also included a fix to a the missing `EnableNotificationAPI `-flag like I mentioned in https://github.com/dokan-dev/dokan-dotnet/pull/236#issuecomment-538937630