### PR TITLE
Fix package license

### DIFF
--- a/DokanNet/DokanNet.csproj
+++ b/DokanNet/DokanNet.csproj
@@ -15,7 +15,7 @@ This is a .NET wrapper over Dokan, and allows you to create your own file system
     <Company>MaximeC</Company>
     <Authors>MaximeC</Authors>
     <PackageProjectUrl>https://dokan-dev.github.io/</PackageProjectUrl>
-    <PackageLicense>license.mit.txt</PackageLicense>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>dokan_logo.png</PackageIcon>
     <RepositoryUrl>https://github.com/dokan-dev/dokan-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -32,7 +32,6 @@ This is a .NET wrapper over Dokan, and allows you to create your own file system
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\license.mit.txt" Pack="true" PackagePath="\" />
     <None Include="..\dokan_logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 


### PR DESCRIPTION
As per NuGet's docs on [Packing a license expression or a license file](https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file), the syntax wasn't quite right.

If you run `dotnet pack` on the project then check `obj/[Debug|Release]/DokanNet.1.3.0.nuspec`, you'll see without these changes there is no `<license` element in the `<metadata>` section, but with this change the license is there.

I opted for using the license expression since it allows customers to see what license it is directly from Visual Studio's Package Manager UI and on nuget.org. When using a file, both just show a link and the customer has to click it to see what the license is. I removed the license file from the package since an expression is used, but if you care about the license file being shipped in the file, feel free to undo that change.

Also FYI, by using the non-standard license file name, GitHub can't detect the license. If you rename the file license.txt, GitHub should be able to start reporting your project as using the MIT license.