### PR TITLE
Add additional options from Dokany v1.4.X

### DIFF
--- a/DokanNet/DokanOptions.cs
+++ b/DokanNet/DokanOptions.cs
@@ -60,5 +60,18 @@ namespace DokanNet
         /// repeatedly rebuilding state that they attach to the FCB header.
         /// </summary>
         EnableFCBGC = 2048,
+
+        /// <summary>
+        /// Enable Case sensitive path.
+        /// By default all path are case insensitive.
+        /// For case sensitive: \dir\File & \diR\file are different files
+        /// but for case insensitive they are the same.
+        /// </summary>
+        CaseSensitive = 4096,
+
+        /// <summary>
+        /// Enables unmounting of network drives via file explorer
+        /// </summary>
+        EnableNetworkUnmount = 8192,
     }
 }


### PR DESCRIPTION
Added values for `DOKAN_OPTION_CASE_SENSITIVE` (as `CaseSensitive`) and `DOKAN_OPTION_ENABLE_UNMOUNT_NETWORK_DRIVE` (as `EnableNetworkUnmount`) to enum `DokanOptions`. Copied over documentation from `dokan\dokan.h`