### PR TITLE
Unmanaged struct keep-alive logic for async mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ TestResults
 *.opendb
 .vs
 *.DotSettings
+**/launchSettings.json

--- a/DokanNet.Tests/DokanNet.Tests.csproj
+++ b/DokanNet.Tests/DokanNet.Tests.csproj
@@ -15,7 +15,7 @@
     net4.6              net4.6
     netstandard1.3      <missing>
     -->
-    <TargetFrameworks>net45;net46;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46</TargetFrameworks>
     
     <!--Add the Target Framework to the output file names. -->
     <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>

--- a/DokanNet.Tests/DokanNet.Tests.csproj
+++ b/DokanNet.Tests/DokanNet.Tests.csproj
@@ -15,7 +15,7 @@
     net4.6              net4.6
     netstandard1.3      <missing>
     -->
-    <TargetFrameworks>net45;net46</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netcoreapp3.1</TargetFrameworks>
     
     <!--Add the Target Framework to the output file names. -->
     <AssemblyName>$(MSBuildProjectName).$(TargetFramework)</AssemblyName>

--- a/DokanNet.Tests/Mounter.cs
+++ b/DokanNet.Tests/Mounter.cs
@@ -24,7 +24,7 @@ namespace DokanNet.Tests
             dokanOptions |= DokanOptions.UserModeLock;
 #endif
 
-            DokanOperationsFixture.Operations.Init();
+            Dokan.Init();
             (mounterThread = new Thread(() => DokanOperationsFixture.Operations.Mount(DokanOperationsFixture.NormalMountPoint, dokanOptions))).Start();
             (mounterThread2 = new Thread(() => DokanOperationsFixture.UnsafeOperations.Mount(DokanOperationsFixture.UnsafeMountPoint, dokanOptions))).Start();
             var drive = new DriveInfo(DokanOperationsFixture.NormalMountPoint);
@@ -44,7 +44,7 @@ namespace DokanNet.Tests
             Dokan.Unmount(DokanOperationsFixture.UnsafeMountPoint[0]);
             Dokan.RemoveMountPoint(DokanOperationsFixture.NormalMountPoint);
             Dokan.RemoveMountPoint(DokanOperationsFixture.UnsafeMountPoint);
-            DokanOperationsFixture.Operations.Shutdown();
+            Dokan.Shutdown();
         }
     }
 }

--- a/DokanNet.Tests/OverlappedTests.cs
+++ b/DokanNet.Tests/OverlappedTests.cs
@@ -323,6 +323,7 @@ namespace DokanNet.Tests
 #endif
         }
 
+#if NETFRAMEWORK
         [TestMethod, TestCategory(TestCategories.Manual)]
         [DeploymentItem("OverlappedTests.Configuration.xml")]
         [DataSource("Microsoft.VisualStudio.TestTools.DataSource.XML", "|DataDirectory|\\OverlappedTests.Configuration.xml", "ConfigRead", DataAccessMethod.Sequential)]
@@ -397,5 +398,6 @@ namespace DokanNet.Tests
             fixture.Verify();
 #endif
         }
+#endif
     }
 }

--- a/DokanNet/DokanHandle.cs
+++ b/DokanNet/DokanHandle.cs
@@ -1,18 +1,41 @@
-﻿using DokanNet.Native;
+﻿using System.Runtime.InteropServices;
+using DokanNet.Native;
 using Microsoft.Win32.SafeHandles;
 
 namespace DokanNet
 {
+    /// <summary>
+    /// This class wraps a native DOKAN_HANDLE.
+    /// 
+    /// Since this class derives form SafeHandle, it is automatically marshalled as
+    /// the native handle it represents to and from native code in for example P/Invoke
+    /// calls. It also uses reference counting and guaranteed to stay alive during such calls.
+    /// <see cref="SafeHandle"/>
+    /// </summary>
     internal class DokanHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
+        /// <summary>
+        /// Initializes a new empty instance, specifying whether the handle is to be reliably released.
+        /// Used internally by native marshaller and not intended to be used directly from user code.
+        /// </summary>
+        /// <param name="ownsHandle">true to reliably release the handle during the finalization phase; false to prevent
+        /// reliable release (not recommended).</param>
         public DokanHandle(bool ownsHandle) : base(ownsHandle)
         {
         }
 
+        /// <summary>
+        /// Initializes an empty instance. Used internally by native marshaller and
+        /// not intended to be used directly from user code.
+        /// </summary>
         public DokanHandle() : base(ownsHandle: true)
         {
         }
 
+        /// <summary>
+        /// Releases the native DOKAN_HANDLE wrapped by this instance.
+        /// </summary>
+        /// <returns>Always returns true</returns>
         protected override bool ReleaseHandle()
         {
             NativeMethods.DokanCloseHandle(handle);

--- a/DokanNet/DokanHandle.cs
+++ b/DokanNet/DokanHandle.cs
@@ -1,0 +1,22 @@
+﻿using DokanNet.Native;
+using Microsoft.Win32.SafeHandles;
+
+namespace DokanNet
+{
+    internal class DokanHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public DokanHandle(bool ownsHandle) : base(ownsHandle)
+        {
+        }
+
+        public DokanHandle() : base(ownsHandle: true)
+        {
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            NativeMethods.DokanCloseHandle(handle);
+            return true;
+        }
+    }
+}

--- a/DokanNet/DokanInstance.cs
+++ b/DokanNet/DokanInstance.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
 using System.Text;
 using DokanNet.Native;
 
@@ -9,11 +11,48 @@ namespace DokanNet
     /// Created by <see cref="Dokan.CreateFileSystem"/>.
     /// It holds all the resources required to be alive for the time of the mount.
     /// </summary>
-    public class DokanInstance
+    public class DokanInstance : IDisposable
     {
-        internal DOKAN_OPTIONS DokanOptions;
-        internal DOKAN_OPERATIONS DokanOperations;
-        internal DokanOperationProxy DokanOperationProxy;
-        internal IntPtr DokanHandle;
+        internal NativeStructWrapper<DOKAN_OPTIONS> DokanOptions;
+        internal NativeStructWrapper<DOKAN_OPERATIONS> DokanOperations;
+        internal DokanHandle DokanHandle;
+        private bool disposedValue;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                    DokanOptions?.Dispose();
+                    DokanOperations?.Dispose();
+                    DokanHandle?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+
+                // TODO: set large fields to null
+                DokanOptions = null;
+                DokanOperations = null;
+                DokanHandle = null;
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        ~DokanInstance()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/DokanNet/DokanInstance.cs
+++ b/DokanNet/DokanInstance.cs
@@ -24,15 +24,15 @@ namespace DokanNet
             {
                 if (disposing)
                 {
-                    // TODO: dispose managed state (managed objects)
-                    DokanOptions?.Dispose();
+                    // Dispose managed state (managed objects)
+                    DokanHandle?.Dispose();     // This calls DokanCloseHandle and waits for dismount
+                    DokanOptions?.Dispose();    // After that, it is safe to free unmanaged memory
                     DokanOperations?.Dispose();
-                    DokanHandle?.Dispose();
                 }
 
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // Free unmanaged resources (unmanaged objects) and override finalizer
 
-                // TODO: set large fields to null
+                // Set fields to null
                 DokanOptions = null;
                 DokanOperations = null;
                 DokanHandle = null;
@@ -41,7 +41,6 @@ namespace DokanNet
             }
         }
 
-        // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
         ~DokanInstance()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/DokanNet/DokanNet.csproj
+++ b/DokanNet/DokanNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net46;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46;net40</TargetFrameworks>
     <AssemblyName>DokanNet</AssemblyName>
     <RootNamespace>DokanNet</RootNamespace>
     <Description>A user mode file system for windows. 
@@ -67,9 +67,4 @@ This is a .NET wrapper over Dokan, and allows you to create your own file system
     <PackageReference Include="StringInterpolationBridgeStrong" Version="0.9.1" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <!--Set to True to run Code Analysis-->
-    <RunCodeAnalysis>False</RunCodeAnalysis>
-  </PropertyGroup>
 </Project>

--- a/DokanNet/Native/DOKAN_OPERATIONS.cs
+++ b/DokanNet/Native/DOKAN_OPERATIONS.cs
@@ -18,7 +18,7 @@ namespace DokanNet.Native
     /// </summary>
     /// <remarks>This is the same struct as <c>_DOKAN_OPERATIONS</c> (dokan.h) in the C version of Dokan.</remarks>
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
-    internal struct DOKAN_OPERATIONS
+    internal sealed class DOKAN_OPERATIONS
     {
         public DokanOperationProxy.ZwCreateFileDelegate ZwCreateFile;
         public DokanOperationProxy.CleanupDelegate Cleanup;

--- a/DokanNet/Native/DOKAN_OPTIONS.cs
+++ b/DokanNet/Native/DOKAN_OPTIONS.cs
@@ -8,7 +8,7 @@ namespace DokanNet.Native
     /// <see cref="NativeMethods.DokanMain"/>
     /// <remarks>This is the same structure as <c>PDOKAN_OPTIONS</c> (dokan.h) in the C version of Dokan.</remarks>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = 4)]
-    internal struct DOKAN_OPTIONS
+    internal sealed class DOKAN_OPTIONS
     {
         /// <summary>
         /// Version of the dokan features requested (version "123" is equal to Dokan version 1.2.3).

--- a/DokanNet/Native/NativeMethods.cs
+++ b/DokanNet/Native/NativeMethods.cs
@@ -40,7 +40,7 @@ namespace DokanNet.Native
         /// <param name="operations">Instance of <see cref="DOKAN_OPERATIONS"/> that will be called for each request made by the kernel.</param>
         /// <returns><see cref="DokanStatus"/></returns>
         [DllImport(DOKAN_DLL, ExactSpelling = true)]
-        public static extern int DokanMain(ref DOKAN_OPTIONS options, ref DOKAN_OPERATIONS operations);
+        public static extern DokanStatus DokanMain([In] DOKAN_OPTIONS options, [In] DOKAN_OPERATIONS operations);
 
         /// <summary>
         /// Mount a new Dokan Volume.
@@ -49,12 +49,12 @@ namespace DokanNet.Native
         /// This function returns directly on device mount or on failure.
         /// <see cref="DokanWaitForFileSystemClosed"/> can be used to wait until the device is unmount.
         /// </summary>
-        /// <param name="options">A <see cref="DOKAN_OPTIONS"/> that describe the mount.</param>
-        /// <param name="operations">Instance of <see cref="DOKAN_OPERATIONS"/> that will be called for each request made by the kernel.</param>
+        /// <param name="options">A <see cref="NativeStructWrapper&lt;DOKAN_OPTIONS&gt;"/> that describe the mount.</param>
+        /// <param name="operations">Instance of <see cref="NativeStructWrapper&lt;DOKAN_OPERATIONS&gt;"/> that will be called for each request made by the kernel.</param>
         /// <param name="dokanInstance">Dokan mount instance context that can be used for related instance calls like <see cref="DokanIsFileSystemRunning"/>.</param>
         /// <returns><see cref="DokanStatus"/></returns>
         [DllImport(DOKAN_DLL, ExactSpelling = true)]
-        public static extern int DokanCreateFileSystem(ref DOKAN_OPTIONS options, ref DOKAN_OPERATIONS operations, ref IntPtr dokanInstance);
+        public static extern DokanStatus DokanCreateFileSystem(SafeBuffer options, SafeBuffer operations, out DokanHandle dokanInstance);
 
         /// <summary>
         /// Check if the FileSystem is still running or not.
@@ -62,7 +62,7 @@ namespace DokanNet.Native
         /// <param name="dokanInstance">The dokan mount context created by <see cref="DokanCreateFileSystem"/>.</param>
         /// <returns>Whether the FileSystem is still running or not.</returns>
         [DllImport(DOKAN_DLL, ExactSpelling = true)]
-        public static extern bool DokanIsFileSystemRunning(IntPtr dokanInstance);
+        public static extern bool DokanIsFileSystemRunning(DokanHandle dokanInstance);
 
         /// <summary>
         /// Wait until the FileSystem is unmount.
@@ -72,7 +72,7 @@ namespace DokanNet.Native
         /// the function does not enter a wait state if the object is not signaled; it always returns immediately. If <param name="milliSeconds"> is INFINITE, the function will return only when the object is signaled.</param>
         /// <returns>See <a href="https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject">WaitForSingleObject</a> for a description of return values.</returns>
         [DllImport(DOKAN_DLL, ExactSpelling = true)]
-        public static extern uint DokanWaitForFileSystemClosed(IntPtr dokanInstance, uint milliSeconds);
+        public static extern uint DokanWaitForFileSystemClosed(DokanHandle dokanInstance, uint milliSeconds);
 
         /// <summary>
         /// Unmount and wait until all resources of the \c DokanInstance are released.
@@ -174,7 +174,7 @@ namespace DokanNet.Native
         /// <param name="isDirectory">Indicates if the path is a directory.</param>
         /// <returns>true if the notification succeeded.</returns>
         [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
-        public static extern bool DokanNotifyCreate(IntPtr dokanInstance,
+        public static extern bool DokanNotifyCreate(DokanHandle dokanInstance,
                                                     [MarshalAs(UnmanagedType.LPWStr)] string filePath,
                                                     [MarshalAs(UnmanagedType.Bool)] bool isDirectory);
 
@@ -186,7 +186,7 @@ namespace DokanNet.Native
         /// <param name="isDirectory">Indicates if the path is a directory.</param>
         /// <returns>true if notification succeeded.</returns>
         [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
-        public static extern bool DokanNotifyDelete(IntPtr dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string filePath,
+        public static extern bool DokanNotifyDelete(DokanHandle dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string filePath,
                                                     [MarshalAs(UnmanagedType.Bool)] bool isDirectory);
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace DokanNet.Native
         /// <param name="filePath">Full path to the file or directory, including mount point.</param>
         /// <returns>true if notification succeeded.</returns>
         [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
-        public static extern bool DokanNotifyUpdate(IntPtr dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string filePath);
+        public static extern bool DokanNotifyUpdate(DokanHandle dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string filePath);
 
         /// <summary>
         /// Notify Dokan that file or directory extended attributes have changed.
@@ -205,7 +205,7 @@ namespace DokanNet.Native
         /// <param name="filePath">Full path to the file or directory, including mount point.</param>
         /// <returns>true if notification succeeded.</returns>
         [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
-        public static extern bool DokanNotifyXAttrUpdate(IntPtr dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string filePath);
+        public static extern bool DokanNotifyXAttrUpdate(DokanHandle dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string filePath);
 
         /// <summary>
         /// Notify Dokan that a file or directory has been renamed.
@@ -218,7 +218,7 @@ namespace DokanNet.Native
         /// <param name="isInSameDirectory">Indicates if OldPath and NewPath have the same parent.</param>
         /// <returns>true if notification succeeded.</returns>
         [DllImport(DOKAN_DLL, CharSet = CharSet.Unicode)]
-        public static extern bool DokanNotifyRename(IntPtr dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string OldPath,
+        public static extern bool DokanNotifyRename(DokanHandle dokanInstance, [MarshalAs(UnmanagedType.LPWStr)] string OldPath,
                                                     [MarshalAs(UnmanagedType.LPWStr)] string newPath,
                                                     [MarshalAs(UnmanagedType.Bool)] bool isDirectory,
                                                     [MarshalAs(UnmanagedType.Bool)] bool isInSameDirectory);

--- a/DokanNet/NativeStructWrapper.cs
+++ b/DokanNet/NativeStructWrapper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace DokanNet
+{
+    internal class NativeStructWrapper<T> : SafeBuffer where T : class
+    {
+        public NativeStructWrapper(T obj) : base(ownsHandle: true)
+        {
+            var size = Marshal.SizeOf(obj);
+            SetHandle(Marshal.AllocHGlobal(size));
+            Initialize((ulong)size);
+            Object = obj;
+            Marshal.StructureToPtr(obj, handle, false);
+        }
+
+        public NativeStructWrapper() : base(ownsHandle: true)
+        {
+        }
+
+        public T Object { get; }
+
+        protected override bool ReleaseHandle()
+        {
+            Marshal.FreeHGlobal(handle);
+            return true;
+        }
+    }
+}

--- a/DokanNet/NativeStructWrapper.cs
+++ b/DokanNet/NativeStructWrapper.cs
@@ -5,8 +5,28 @@ using System.Text;
 
 namespace DokanNet
 {
+    /// <summary>
+    /// This class allocates unmanaged memory for a native structure and initializes
+    /// that memory by marshalling a managed object. It gurantees that the managed
+    /// object stays alive and the unmanaged memory block is valid for at least the
+    /// lifetime of this object and that the unmanaged memory is released when this
+    /// object is disposed.
+    /// 
+    /// Since this class derives form SafeBuffer there are many instance methods
+    /// available to read and modify the unmanaged buffer in a safe way and when
+    /// marshalled to native code in for example a P/Invoke call, it gets automatically
+    /// translated to the address of the unmanaged memory block. It also uses reference
+    /// counting and is guaranteed to stay alive during such calls.
+    /// <see cref="SafeBuffer"/>
+    /// </summary>
+    /// <typeparam name="T">Type of managed object</typeparam>
     internal class NativeStructWrapper<T> : SafeBuffer where T : class
     {
+        /// <summary>
+        /// Initializes a new instance by allocating unmanaged memory and marshalling
+        /// the supplied managed object to that memory.
+        /// </summary>
+        /// <param name="obj">Managed object to marshal to unmanaged memory</param>
         public NativeStructWrapper(T obj) : base(ownsHandle: true)
         {
             var size = Marshal.SizeOf(obj);
@@ -16,12 +36,23 @@ namespace DokanNet
             Marshal.StructureToPtr(obj, handle, false);
         }
 
+        /// <summary>
+        /// Initializes an empty instance. Used internally by native marshaller and
+        /// not intended to be used directly from user code.
+        /// </summary>
         public NativeStructWrapper() : base(ownsHandle: true)
         {
         }
 
+        /// <summary>
+        /// Managed object that was originally marshalled to unmanaged memory.
+        /// </summary>
         public T Object { get; }
 
+        /// <summary>
+        /// Releases unmanaged memory used by this instance.
+        /// </summary>
+        /// <returns>Always returns true</returns>
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);

--- a/sample/DokanNetMirror/DokanNetMirror.csproj
+++ b/sample/DokanNetMirror/DokanNetMirror.csproj
@@ -14,10 +14,6 @@
     <PackageReference Include="StringInterpolationBridgeStrong" Version="0.9.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
   <PropertyGroup>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <!--Set to True to run Code Analysis-->

--- a/sample/DokanNetMirror/DokanNetMirror.csproj
+++ b/sample/DokanNetMirror/DokanNetMirror.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="StringInterpolationBridgeStrong" Version="0.9.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
   <PropertyGroup>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <!--Set to True to run Code Analysis-->

--- a/sample/DokanNetMirror/Program.cs
+++ b/sample/DokanNetMirror/Program.cs
@@ -33,12 +33,16 @@ namespace DokanNetMirror
                     ? new UnsafeMirror(mirrorPath) 
                     : new Mirror(mirrorPath);
 
-                mirror.Init();
-                DokanInstance dokanInstance = mirror.CreateFileSystem(mountPath, DokanOptions.DebugMode | DokanOptions.EnableNotificationAPI);
-                var notify = new Notify();
-                notify.Start(mirrorPath, mountPath, dokanInstance);
-                mirror.WaitForFileSystemClosed(dokanInstance, uint.MaxValue);
-                mirror.Shutdown();
+                Dokan.Init();
+
+                using (DokanInstance dokanInstance = mirror.CreateFileSystem(mountPath, DokanOptions.DebugMode | DokanOptions.EnableNotificationAPI))
+                {
+                    var notify = new Notify();
+                    notify.Start(mirrorPath, mountPath, dokanInstance);
+                    dokanInstance.WaitForFileSystemClosed(uint.MaxValue);
+                }
+
+                Dokan.Shutdown();
 
                 Console.WriteLine(@"Success");
             }

--- a/sample/DokanNetMirror/Properties/launchSettings.json
+++ b/sample/DokanNetMirror/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "DokanNetMirror": {
-      "commandName": "Project",
-      "commandLineArgs": "-what=\"S:\\RAM files\""
-    }
-  }
-}

--- a/sample/DokanNetMirror/Properties/launchSettings.json
+++ b/sample/DokanNetMirror/Properties/launchSettings.json
@@ -1,11 +1,8 @@
 {
   "profiles": {
-    "DokanNetMirror (net4.6)": {
-      "commandName": "Project"
-    },
-    "DokanNetMirror (net4.0)": {
-      "commandName": "Executable",
-      "executablePath": "$(ProjectDir)\\bin\\$(Configuration)\\net4.0\\win\\DokanNetMirror.exe"
+    "DokanNetMirror": {
+      "commandName": "Project",
+      "commandLineArgs": "-what=\"S:\\RAM files\""
     }
   }
 }

--- a/sample/RegistryFS/Program.cs
+++ b/sample/RegistryFS/Program.cs
@@ -318,9 +318,9 @@ namespace RegistryFS
             try
             {
                 var rfs = new RFS();
-                rfs.Init();
+                Dokan.Init();
                 rfs.Mount("r:\\", DokanOptions.DebugMode | DokanOptions.StderrOutput);
-                rfs.Shutdown();
+                Dokan.Shutdown();
                 Console.WriteLine(@"Success");
             }
             catch (DokanException ex)


### PR DESCRIPTION
* Implemented manual marshalling of structures and wrapped them and original managed objects in SafeBuffer derived classes to keep managed data alive while the native structure is in use.
* DOKAN_OPTIONS and DOKAN_OPERATIONS changed to classes instead of structs so that they do not need as much copying around and it also makes the "keep-alive" logic simpler.
* IDisposable DokanInstance with a Dispose method that cleans up native allocations.
* DokanHandle class that implements SafeHandle logic for Dokan handles.
* Dokan.CloseFileSystem() removed and replaced with DokanInstance.Dispose().
* Added launchSettings.json to .gitignore because that file contains settings that each developer mostly want to have their own settings. It is only used when debugging in Visual Studio.
* Had to remove netstandard1.3 support to make things simpler. I assume netstandard2.0 is old enough these days anyway.
* Added netcoreapp3.1 target framework for test project and some if's around parts that are .NET Framework specific. This makes it easier to test netstandard2.0 library.
