### PR TITLE
Prevent garbage collection of delegates during DokanMain

### DIFF
--- a/DokanNet/Native/NativeMethods.cs
+++ b/DokanNet/Native/NativeMethods.cs
@@ -36,11 +36,11 @@ namespace DokanNet.Native
         /// This function block until the device is unmount.
         /// If the mount fail, it will directly return an error.
         /// </summary>
-        /// <param name="options">A <see cref="DOKAN_OPTIONS"/> that describe the mount.</param>
-        /// <param name="operations">Instance of <see cref="DOKAN_OPERATIONS"/> that will be called for each request made by the kernel.</param>
+        /// <param name="options">A <see cref="NativeStructWrapper&lt;DOKAN_OPTIONS&gt;"/> that describe the mount.</param>
+        /// <param name="operations">Instance of <see cref="NativeStructWrapper&lt;DOKAN_OPERATIONS&gt;"/> that will be called for each request made by the kernel.</param>
         /// <returns><see cref="DokanStatus"/></returns>
         [DllImport(DOKAN_DLL, ExactSpelling = true)]
-        public static extern DokanStatus DokanMain([In] DOKAN_OPTIONS options, [In] DOKAN_OPERATIONS operations);
+        public static extern DokanStatus DokanMain(SafeBuffer options, SafeBuffer operations);
 
         /// <summary>
         /// Mount a new Dokan Volume.


### PR DESCRIPTION
This is a weird one: When calling Dokan.Mount, my application reproducibly behaves as follows:

1. It makes several successful calls to my implementaion of IDokanOperations.
2. After a short time, one such call fails, with the callbackOnCollectedDelegate MDA[1] reporting that the delegate `DokanNet!DokanNet.DokanOperationProxy+GetFileInformationDelegate::Invoke` was called from unmanaged code even though it had already been garbage collected. This happens while the call to Dokan.Mount is still running.

My take on this is as follows:

- Dokan.Mount calls the unmanaged DokanMain of the Dokany C library, passing an instance of the class DOKAN_OPERATIONS, which requires marshalling[3].
- DOKAN_OPERATIONS is considered unblittable[4] because it contains delegates. Therefore, the marshaller creates a copy[5] of this class in the correct format and passes a pointer to that copy to DokanMain.
- As soon as a copy is created, the original DOKAN_OPERATIONS is not strictly required anymore and can be garbage collected.
- Garbage collection may happen right before to call to DokanMain. Apparently, it may also happen while DokanMain is running due to multi-threading.
- The delegates are garbage collected too, since they are only referenced by DOKAN_OPERATIONS.

This pull request is my attempt at fixing it. It has solved the problem for me. However, I am not quite sure if this works out in all cases. The garbage collector can basically do two things:

- Remove data from memory. In my pull request, this is prevented using GC.KeepAlive[2].
- Relocate data (compaction). Could this happen to delegates and is it prevented? Would they need to be pinned[5] in some way?


[1]: https://docs.microsoft.com/en-us/dotnet/framework/debug-trace-profile/callbackoncollecteddelegate-mda
[2]: https://docs.microsoft.com/en-us/dotnet/api/system.gc.keepalive
[3]: https://docs.microsoft.com/en-us/dotnet/framework/interop/interop-marshaling
[4]: https://docs.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types
[5]: https://docs.microsoft.com/en-us/dotnet/framework/interop/copying-and-pinning