### PR TITLE
Fixed a crash in `ReadFileProxy` when debug logging is enabled

### DIFF
--- a/DokanNet/DokanOperationProxy.cs
+++ b/DokanNet/DokanOperationProxy.cs
@@ -398,10 +398,10 @@ namespace DokanNet
             {
                 if (logger.DebugEnabled)
                 {
-                    logger.Debug("ReadFileProxy : " + rawFileName);
-                    logger.Debug("\tBufferLength\t" + rawBufferLength);
-                    logger.Debug("\tOffset\t" + rawOffset);
-                    logger.Debug("\tContext\t" + rawFileInfo);
+                    logger.Debug("ReadFileProxy : {0}", rawFileName);
+                    logger.Debug("\tBufferLength\t{0}", rawBufferLength);
+                    logger.Debug("\tOffset\t{0}", rawOffset);
+                    logger.Debug("\tContext\t{0}", rawFileInfo);
                 }
 
                 // Check if the file system has implemented the unsafe Dokan interface.
@@ -426,7 +426,7 @@ namespace DokanNet
                     }
                 }
 
-                if (logger.DebugEnabled) logger.Debug("ReadFileProxy : " + rawFileName + " Return : " + result + " ReadLength : " + rawReadLength);
+                if (logger.DebugEnabled) logger.Debug("ReadFileProxy : {0} Return : {1} ReadLength : {2}", rawFileName, result, rawReadLength);
                 return result;
             }
             catch (Exception ex)


### PR DESCRIPTION
The call ends up looking like this:

```csharp
logger.Debug("\tContext\t{FileStream, ...}")
```

And the `Debug` interprets it as a format string, and the part of the string between curly braces gets incorrectly interpreted as a placeholder specification.

IMHO, a mature logging library should be used instead like [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/)

Or at the very least to prevent an issue like this there should be an overload without `params object[] args` which would have been selected instead, and which would take the string as the final message rather than format string.