### PR TITLE
fix: use baseName + GetInvalidFileNameChars for invalid name check

### DIFF
--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -308,7 +308,7 @@ internal class Mirror : IDokanOperations2
             result);
     }
 
-    private static readonly char[] invalidPathChars = Path.GetInvalidPathChars();
+    private static readonly char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
 
     public void Cleanup(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info)
     {


### PR DESCRIPTION
The previous code checked the full fileName (which includes path separators) against GetInvalidPathChars. Semantically, we should only check the file name portion (baseName) and use the stricter GetInvalidFileNameChars which includes :*?"<>| etc.