### PR TITLE
Fix/invalid name check uses basename

### DIFF
--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -214,7 +214,8 @@ internal class Mirror : IDokanOperations2
                     }
                     else
                     {
-                        var status = fileName.Span.IndexOfAny(invalidPathChars) >= 0
+                        var baseName = Path.GetFileName(fileName.ToString());
+                        var status = baseName.IndexOfAny(invalidFileNameChars) >= 0
                             ? DokanResult.InvalidName
                             : DokanResult.FileNotFound;
 

--- a/sample/DokanNetMirror/Mirror.cs
+++ b/sample/DokanNetMirror/Mirror.cs
@@ -308,7 +308,7 @@ internal class Mirror : IDokanOperations2
             result);
     }
 
-    private static readonly char[] invalidPathChars = Path.GetInvalidPathChars();
+    private static readonly char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
 
     public void Cleanup(ReadOnlyNativeMemory<char> fileName, ref DokanFileInfo info)
     {


### PR DESCRIPTION
The previous code checked the full fileName (which includes path separators) against GetInvalidPathChars. Semantically, we should only check the file name portion (baseName) and use the stricter GetInvalidFileNameChars which includes :*?"<>| etc.